### PR TITLE
Some UX improvements

### DIFF
--- a/script-nanos.ld
+++ b/script-nanos.ld
@@ -124,6 +124,7 @@ SECTIONS
   {
     bss_start = .; 
     *(.legacy_globals)
+    *(.bss.vars) /* legacy global variable not following the G_ convention for globals */
   }  > SRAM = 0x00
   .ol1 bss_start (NOLOAD) : {
     *(.new_globals)

--- a/src/boilerplate/dispatcher.c
+++ b/src/boilerplate/dispatcher.c
@@ -266,7 +266,7 @@ static void dispatcher_loop() {
         io_send_sw(SW_BAD_STATE);
     }
 
-    // We call the temination callback if given, but only if the UX is "dirty", that is either
+    // We call the termination callback if given, but only if the UX is "dirty", that is either
     // - there was some kind of UX flow with user interaction;
     // - background processing took long enough that the "Processing..." screen was shown.
     bool is_ux_dirty = G_dispatcher_state.had_ux_flow || G_was_processing_screen_shown;

--- a/src/boilerplate/io.c
+++ b/src/boilerplate/io.c
@@ -43,6 +43,10 @@ struct {
     bool processing : 1;
 } G_is_timeout_active;
 
+// set to true when the "Processing..." screen is shown, in order for the dispatcher to know if the
+// UX is not in idle state at the end of a command handler.
+bool G_was_processing_screen_shown;
+
 uint16_t G_interruption_timeout_start_tick;
 uint16_t G_processing_timeout_start_tick;
 
@@ -71,6 +75,12 @@ void io_clear_processing_timeout() {
     G_is_timeout_active.processing = false;
 }
 
+void io_reset_timeouts() {
+    io_clear_interruption_timeout();
+    io_clear_processing_timeout();
+    G_was_processing_screen_shown = false;
+}
+
 uint8_t io_event(uint8_t channel) {
     (void) channel;
 
@@ -95,6 +105,7 @@ uint8_t io_event(uint8_t channel) {
                 G_ticks - G_processing_timeout_start_tick >= PROCESSING_TIMEOUT_TICKS) {
                 io_clear_processing_timeout();
 
+                G_was_processing_screen_shown = true;
                 ux_flow_init(0, ux_processing_flow, NULL);
             }
 

--- a/src/boilerplate/io.c
+++ b/src/boilerplate/io.c
@@ -32,10 +32,43 @@
 extern dispatcher_context_t G_dispatcher_context;
 extern command_processor_t G_command_continuation;
 
-uint32_t G_output_len = 0;
+uint16_t G_output_len = 0;
+
+// Counter incremented at every tick
+// The initial value does not matter, as only the difference between timeframes is used.
+uint16_t G_ticks;
+
+struct {
+    bool interruption : 1;
+    bool processing : 1;
+} G_is_timeout_active;
+
+uint16_t G_interruption_timeout_start_tick;
+uint16_t G_processing_timeout_start_tick;
+
+UX_STEP_NOCB(ux_processing_flow_1_step, pn, {&C_icon_processing, "Processing..."});
+UX_FLOW(ux_processing_flow, &ux_processing_flow_1_step);
 
 void io_seproxyhal_display(const bagl_element_t *element) {
     io_seproxyhal_display_default((bagl_element_t *) element);
+}
+
+void io_start_interruption_timeout() {
+    G_interruption_timeout_start_tick = G_ticks;
+    G_is_timeout_active.interruption = true;
+}
+
+void io_clear_interruption_timeout() {
+    G_is_timeout_active.interruption = false;
+}
+
+void io_start_processing_timeout() {
+    G_processing_timeout_start_tick = G_ticks;
+    G_is_timeout_active.processing = true;
+}
+
+void io_clear_processing_timeout() {
+    G_is_timeout_active.processing = false;
 }
 
 uint8_t io_event(uint8_t channel) {
@@ -56,6 +89,25 @@ uint8_t io_event(uint8_t channel) {
             UX_DISPLAYED_EVENT({});
             break;
         case SEPROXYHAL_TAG_TICKER_EVENT:
+            ++G_ticks;
+
+            if (G_is_timeout_active.processing &&
+                G_ticks - G_processing_timeout_start_tick >= PROCESSING_TIMEOUT_TICKS) {
+                io_clear_processing_timeout();
+
+                ux_flow_init(0, ux_processing_flow, NULL);
+            }
+
+            if (G_is_timeout_active.interruption &&
+                G_ticks - G_interruption_timeout_start_tick >= INTERRUPTION_TIMEOUT_TICKS) {
+                io_clear_interruption_timeout();
+
+                // TODO: It would be better to have the dispatcher be notified somehow.
+                //       This would require some tampering with the io_exchange in
+                //       process_interruption.
+                THROW(EXCEPTION_IO_RESET);
+            }
+
             UX_TICKER_EVENT(G_io_seproxyhal_spi_buffer, {});
             break;
         default:

--- a/src/boilerplate/io.h
+++ b/src/boilerplate/io.h
@@ -42,15 +42,15 @@ void io_clear_interruption_timeout();
 void io_start_processing_timeout();
 
 /**
+ * Removes the timeout started from io_start_processing_timeout.
+ */
+void io_clear_processing_timeout();
+
+/**
  * Clears both the interruption and processing timeouts, and sets G_was_processing_screen_shown to
  * false.
  */
 void io_reset_timeouts();
-
-/**
- * TODO: docs
- */
-void io_clear_processing_timeout();
 
 /**
  * TODO: docs

--- a/src/boilerplate/io.h
+++ b/src/boilerplate/io.h
@@ -20,6 +20,32 @@ uint8_t io_event(uint8_t channel);
 
 uint16_t io_exchange_al(uint8_t channel, uint16_t tx_len);
 
+#define INTERRUPTION_TIMEOUT_TICKS 50
+#define PROCESSING_TIMEOUT_TICKS   10
+
+/**
+ * Instructs io_event to reset the app if INTERRUPTION_TIMEOUT_TICKS tick events are received before
+ * io_clear_interruption_timeout is called. Used to cause an app reset if the client stop responding
+ * while an APDU is being processed.
+ */
+void io_start_interruption_timeout();
+
+/**
+ * Removes the timeout started from io_start_interruption_timeout.
+ */
+void io_clear_interruption_timeout();
+
+/**
+ * Instructs io_event to show the "Processing..." screen if PROCESSING_TIMEOUT_TICKS tick events are
+ * received before io_clear_interruption_timeout is called.
+ */
+void io_start_processing_timeout();
+
+/**
+ * TODO: docs
+ */
+void io_clear_processing_timeout();
+
 /**
  * TODO: docs
  */

--- a/src/boilerplate/io.h
+++ b/src/boilerplate/io.h
@@ -42,6 +42,12 @@ void io_clear_interruption_timeout();
 void io_start_processing_timeout();
 
 /**
+ * Clears both the interruption and processing timeouts, and sets G_was_processing_screen_shown to
+ * false.
+ */
+void io_reset_timeouts();
+
+/**
  * TODO: docs
  */
 void io_clear_processing_timeout();

--- a/src/globals.h
+++ b/src/globals.h
@@ -17,7 +17,7 @@ extern uint8_t G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
 /**
  * Global variable with the lenght of APDU response to send back.
  */
-extern uint32_t G_output_len;
+extern uint16_t G_output_len;
 
 /**
  * Global structure to perform asynchronous UX aside IO operations.

--- a/src/legacy/main_old.c
+++ b/src/legacy/main_old.c
@@ -208,43 +208,43 @@ void settings_submenu_selector(unsigned int idx) {
 }
 
 //////////////////////////////////////////////////////////////////////
-UX_STEP_NOCB(
-    ux_idle_flow_1_step,
-    nn,
-    {
-      "Application",
-      "is ready",
-    });
-UX_STEP_CB(
-    ux_idle_flow_2_step,
-    pb,
-    ux_menulist_init(0, settings_submenu_getter, settings_submenu_selector),
-    {
-      &C_icon_coggle,
-      "Settings",
-    });
-UX_STEP_NOCB(
-    ux_idle_flow_3_step,
-    bn,
-    {
-      "Version",
-      APPVERSION,
-    });
-UX_STEP_CB(
-    ux_idle_flow_4_step,
-    pb,
-    os_sched_exit(-1),
-    {
-      &C_icon_dashboard_x,
-      "Quit",
-    });
-UX_FLOW(ux_idle_flow,
-  &ux_idle_flow_1_step,
-  &ux_idle_flow_2_step,
-  &ux_idle_flow_3_step,
-  &ux_idle_flow_4_step,
-  FLOW_LOOP
-);
+// UX_STEP_NOCB(
+//     ux_idle_flow_1_step,
+//     nn,
+//     {
+//       "Application",
+//       "is ready",
+//     });
+// UX_STEP_CB(
+//     ux_idle_flow_2_step,
+//     pb,
+//     ux_menulist_init(0, settings_submenu_getter, settings_submenu_selector),
+//     {
+//       &C_icon_coggle,
+//       "Settings",
+//     });
+// UX_STEP_NOCB(
+//     ux_idle_flow_3_step,
+//     bn,
+//     {
+//       "Version",
+//       APPVERSION,
+//     });
+// UX_STEP_CB(
+//     ux_idle_flow_4_step,
+//     pb,
+//     os_sched_exit(-1),
+//     {
+//       &C_icon_dashboard_x,
+//       "Quit",
+//     });
+// UX_FLOW(ux_idle_flow,
+//   &ux_idle_flow_1_step,
+//   &ux_idle_flow_2_step,
+//   &ux_idle_flow_3_step,
+//   &ux_idle_flow_4_step,
+//   FLOW_LOOP
+// );
 
 //////////////////////////////////////////////////////////////////////
 UX_STEP_NOCB(
@@ -691,12 +691,17 @@ UX_FLOW(ux_request_segwit_input_approval_flow,
 );
 
 
+void ui_menu_main(); // new app's idle screen
+
 void ui_idle(void) {
-    // reserve a display stack slot if none yet
-    if(G_ux.stack_count == 0) {
-        ux_stack_push();
-    }
-    ux_flow_init(0, ux_idle_flow, NULL);
+    // // reserve a display stack slot if none yet
+    // if(G_ux.stack_count == 0) {
+    //     ux_stack_push();
+    // }
+    // ux_flow_init(0, ux_idle_flow, NULL);
+
+    // Use the new app's idle screen
+    ui_menu_main();
 }
 
 // override point, but nothing more to do

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,11 @@
 extern unsigned int app_stack_canary;
 #endif
 
+extern struct {
+    bool interruption : 1;
+    bool processing : 1;
+} G_is_timeout_active;
+
 uint8_t G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
 ux_state_t G_ux;
 bolos_ux_params_t G_ux_params;
@@ -355,6 +360,10 @@ __attribute__((section(".boot"))) int main(int arg0) {
 
     // ensure exception will work as planned
     os_boot();
+
+    // TODO: hide these in the boilerplate, maybe in an init_dispatcher function
+    G_is_timeout_active.interruption = false;
+    G_is_timeout_active.processing = false;
 
     if (!arg0) {
         // Bitcoin application launched from dashboard

--- a/src/main.c
+++ b/src/main.c
@@ -290,7 +290,7 @@ void coin_main(btchip_altcoin_config_t *coin_config) {
                 USB_power(0);
                 USB_power(1);
 
-                ui_idle();
+                ui_menu_main();
 
 #ifdef HAVE_BLE
                 BLE_power(0, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -44,11 +44,6 @@
 extern unsigned int app_stack_canary;
 #endif
 
-extern struct {
-    bool interruption : 1;
-    bool processing : 1;
-} G_is_timeout_active;
-
 uint8_t G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
 ux_state_t G_ux;
 bolos_ux_params_t G_ux_params;
@@ -361,9 +356,7 @@ __attribute__((section(".boot"))) int main(int arg0) {
     // ensure exception will work as planned
     os_boot();
 
-    // TODO: hide these in the boilerplate, maybe in an init_dispatcher function
-    G_is_timeout_active.interruption = false;
-    G_is_timeout_active.processing = false;
+    io_reset_timeouts();
 
     if (!arg0) {
         // Bitcoin application launched from dashboard

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,8 @@ def client(request, hid) -> Union[HIDClient, SpeculosClient]:
         client = HIDClient()
     else:
         client = SpeculosClient(
-            str(conftest_folder_path.parent.joinpath("bin/app.elf"))
+            str(conftest_folder_path.parent.joinpath("bin/app.elf")),
+            ['--sdk', '2.1']
         )
 
         try:


### PR DESCRIPTION
- Show a "processing" screen when handling an APDU takes more than ~1 sec
- Reset app when the client stops responding during an interruption. (~5 sec)
- Always use the new app's dashboard.
- Avoid redrawing the main menu after an APDU if not necessary.

Also few smaller technical improvements.