### PR TITLE
handle new transaction format in peercoin

### DIFF
--- a/src/legacy/btchip_transaction.c
+++ b/src/legacy/btchip_transaction.c
@@ -270,8 +270,9 @@ void transaction_parse(unsigned char parseMode) {
                     }
 
                     if (G_coin_config->flags & FLAG_PEERCOIN_SUPPORT) {
-                        if ((G_coin_config->family ==
-                            BTCHIP_FAMILY_PEERCOIN) ||
+                        if (((G_coin_config->family ==
+                            BTCHIP_FAMILY_PEERCOIN) &&
+                            (btchip_context_D.transactionVersion[0] < 3)) ||
                             ((G_coin_config->family == BTCHIP_FAMILY_STEALTH) &&
                             (btchip_context_D.transactionVersion[0] < 2))) {
                             // Timestamp


### PR DESCRIPTION
very simple change, as long as there's no other BTCHIP_FAMILY_PEERCOIN with v3 transactions in old format