### PR TITLE
Add "Sign message" feature

### DIFF
--- a/bitcoin_client/ledger_bitcoin/client.py
+++ b/bitcoin_client/ledger_bitcoin/client.py
@@ -211,13 +211,30 @@ class NewClient(Client):
         return {int(res[0]): res[1:] for res in results}
 
     def get_master_fingerprint(self) -> bytes:
-
         sw, response = self._make_request(self.builder.get_master_fingerprint())
 
         if sw != 0x9000:
             raise DeviceException(error_code=sw, ins=BitcoinInsType.GET_EXTENDED_PUBKEY)
 
         return response
+
+    def sign_message(self, message: Union[str, bytes], bip32_path: str) -> str:
+        if isinstance(message, str):
+            message_bytes = message.encode("utf-8")
+        else:
+            message_bytes = message
+
+        chunks = [message_bytes[64 * i: 64 * i + 64] for i in range((len(message_bytes) + 63) // 64)]
+
+        client_intepreter = ClientCommandInterpreter()
+        client_intepreter.add_known_list(chunks)
+
+        sw, response = self._make_request(self.builder.sign_message(message_bytes, bip32_path), client_intepreter)
+
+        if sw != 0x9000:
+            raise DeviceException(error_code=sw, ins=BitcoinInsType.GET_EXTENDED_PUBKEY)
+
+        return base64.b64encode(response).decode('utf-8')
 
 
 def createClient(comm_client: Optional[TransportClient] = None, chain: Chain = Chain.MAIN, debug: bool = False) -> Union[LegacyClient, NewClient]:

--- a/dev-tools/tag_apdus.py
+++ b/dev-tools/tag_apdus.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass
 
 from typing import List, Mapping, Optional
 
-from ledger_bitcoin.client_command import ClientCommandCode
-from ledger_bitcoin.command_builder import BitcoinInsType, FrameworkInsType, BitcoinCommandBuilder
-from ledger_bitcoin.common import ByteStreamParser, sha256
+from bitcoin_client.ledger_bitcoin.client_command import ClientCommandCode
+from bitcoin_client.ledger_bitcoin.command_builder import BitcoinInsType, FrameworkInsType, BitcoinCommandBuilder
+from bitcoin_client.ledger_bitcoin.common import ByteStreamParser, sha256
 
 """
 Parses from standard input a transcript of a complete APDU exchange with the app, formatted as following:
@@ -37,6 +37,8 @@ and produces a more human-readable representation of the transcript:
 <= ⏸ GET_PREIMAGE(hash=1ff8e5d0d3724c1bc905b0ff9ed0ae11980391e98f4e692cf48b3b342876f5bf)
 => ▶ <preimage_len:138><payload_size: 138><payload:005b66356163633266642f3438272f31272f30272f31275d747075624446417145474e7961643335596748387a787678465a714e556f507472356d446f6a7337777a6258514248545a347848655658473677324876734b766a4270615270546d6a59446a64506735773263365776753851426b794d44726d4257644379716b444d3772655373592f2a2a>)
 <= a47f78a76a965d19df634511401803db2af6c5883033bb8d1f1249f93317cdc9ff96c09cfacf89f836ded409b7315b9d7f242db8033e4de4db1cb4c275153988 9000
+
+It must be run from the root of the repository.
 """
 
 
@@ -241,8 +243,25 @@ class GetMasterFingerprintCommandFormatter(BitcoinCommandFormatter):
         print("=> GET_MASTER_FINGERPRINT()")
 
 
+class SignMessageCommandFormatter(BitcoinCommandFormatter):
+    ins_type = BitcoinInsType.SIGN_MESSAGE
+
+    @classmethod
+    def format_request(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+        bip32_path_len = stream.read_bytes(1)[0]
+        bip32_path = [stream.read_uint(4, 'big')
+                      for _ in range(bip32_path_len)]
+
+        message_length = stream.read_varint()
+        message_merkle_root = stream.read_bytes(32)
+        stream.assert_empty()
+
+        print(
+            f"=> SIGN_MESSAGE(path=\"{format_bip32_path(bip32_path)}\",message_length={message_length},message_tree_hash={format_merkle_root(message_merkle_root, context)})")
+
+
 bitcoin_command_formatters: List[BitcoinCommandFormatter] = [GetExtendedPubkeyCommandFormatter, RegisterWalletCommandFormatter,
-                                                             GetWalletAddressCommandFormatter, SignPsbtCommandFormatter, GetMasterFingerprintCommandFormatter]
+                                                             GetWalletAddressCommandFormatter, SignPsbtCommandFormatter, GetMasterFingerprintCommandFormatter, SignMessageCommandFormatter]
 bitcoin_command_formatters_map: Mapping[BitcoinInsType, BitcoinCommandFormatter] = {
     f.ins_type: f for f in bitcoin_command_formatters
 }

--- a/dev-tools/tag_apdus.py
+++ b/dev-tools/tag_apdus.py
@@ -143,12 +143,12 @@ def format_merkle_root(root: bytes, context: CommandContext) -> str:
 class BitcoinCommandFormatter:
     ins_type: BitcoinInsType
 
-    @classmethod
-    def format_request(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_request(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         raise NotImplementedError
 
-    @classmethod
-    def format_response(cls, response: bytes, sw: int, context: CommandContext):
+    @staticmethod
+    def format_response(response: bytes, sw: int, context: CommandContext):
         if len(response) == 0:
             print("<= {:04x}".format(sw))
         else:
@@ -158,8 +158,8 @@ class BitcoinCommandFormatter:
 class GetExtendedPubkeyCommandFormatter(BitcoinCommandFormatter):
     ins_type = BitcoinInsType.GET_EXTENDED_PUBKEY
 
-    @classmethod
-    def format_request(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_request(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         assert len(apdu.data) >= 2
         assert apdu.p1 == 0 and apdu.p2 == 0
 
@@ -180,8 +180,8 @@ class GetExtendedPubkeyCommandFormatter(BitcoinCommandFormatter):
 class RegisterWalletCommandFormatter(BitcoinCommandFormatter):
     ins_type = BitcoinInsType.REGISTER_WALLET
 
-    @classmethod
-    def format_request(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_request(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         assert len(apdu.data) >= 1
         wallet_len = apdu.data[0]
         assert len(apdu.data) == 1 + wallet_len
@@ -192,8 +192,8 @@ class RegisterWalletCommandFormatter(BitcoinCommandFormatter):
 class GetWalletAddressCommandFormatter(BitcoinCommandFormatter):
     ins_type = BitcoinInsType.GET_WALLET_ADDRESS
 
-    @classmethod
-    def format_request(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_request(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         assert len(apdu.data) == 1 + 32 + 32 + 1 + 4
 
         display = apdu.data[0]
@@ -211,8 +211,8 @@ class GetWalletAddressCommandFormatter(BitcoinCommandFormatter):
 class SignPsbtCommandFormatter(BitcoinCommandFormatter):
     ins_type = BitcoinInsType.SIGN_PSBT
 
-    @classmethod
-    def format_request(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_request(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         global_map_commitment_size = stream.read_varint()
         global_map_commitment_keys_root = stream.read_bytes(32)
         global_map_commitment_values_root = stream.read_bytes(32)
@@ -237,8 +237,8 @@ class SignPsbtCommandFormatter(BitcoinCommandFormatter):
 class GetMasterFingerprintCommandFormatter(BitcoinCommandFormatter):
     ins_type = BitcoinInsType.GET_MASTER_FINGERPRINT
 
-    @classmethod
-    def format_request(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_request(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         assert len(apdu.data) == 0
         print("=> GET_MASTER_FINGERPRINT()")
 
@@ -246,8 +246,8 @@ class GetMasterFingerprintCommandFormatter(BitcoinCommandFormatter):
 class SignMessageCommandFormatter(BitcoinCommandFormatter):
     ins_type = BitcoinInsType.SIGN_MESSAGE
 
-    @classmethod
-    def format_request(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_request(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         bip32_path_len = stream.read_bytes(1)[0]
         bip32_path = [stream.read_uint(4, 'big')
                       for _ in range(bip32_path_len)]
@@ -270,24 +270,24 @@ bitcoin_command_formatters_map: Mapping[BitcoinInsType, BitcoinCommandFormatter]
 class ClientCommandFormatter:
     code: ClientCommandCode
 
-    @classmethod
-    def format_cmd_request(cls, response: bytes, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_request(response: bytes, stream: ByteStreamParser, context: CommandContext):
         raise NotImplementedError
 
-    @classmethod
-    def format_cmd_response(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_response(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         raise NotImplementedError
 
 
 class YieldClientCommandFormatter(ClientCommandFormatter):
     code = ClientCommandCode.YIELD
 
-    @classmethod
-    def format_cmd_request(cls, response: bytes, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_request(response: bytes, stream: ByteStreamParser, context: CommandContext):
         print(f"<= ⏸ YIELD({response[1:].hex()})")
 
-    @classmethod
-    def format_cmd_response(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_response(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         assert len(apdu.data) == 0
         print(f"=> ▶")
 
@@ -295,8 +295,8 @@ class YieldClientCommandFormatter(ClientCommandFormatter):
 class GetPreimageClientCommandFormatter(ClientCommandFormatter):
     code = ClientCommandCode.GET_PREIMAGE
 
-    @classmethod
-    def format_cmd_request(cls, response: bytes, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_request(response: bytes, stream: ByteStreamParser, context: CommandContext):
         # skip first byte, but it must be 0
         if stream.read_bytes(1) != b'\0':
             raise RuntimeError(
@@ -307,8 +307,8 @@ class GetPreimageClientCommandFormatter(ClientCommandFormatter):
 
         print(f"<= ⏸ GET_PREIMAGE(hash={context.get_preimage__hash.hex()})")
 
-    @classmethod
-    def format_cmd_response(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_response(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         preimage_len = stream.read_varint()
         payload_size = stream.read_bytes(1)[0]
         payload = stream.read_bytes(payload_size)
@@ -359,8 +359,8 @@ class GetPreimageClientCommandFormatter(ClientCommandFormatter):
 class GetMerkleLeafProofClientCommandFormatter(ClientCommandFormatter):
     code = ClientCommandCode.GET_MERKLE_LEAF_PROOF
 
-    @classmethod
-    def format_cmd_request(cls, response: bytes, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_request(response: bytes, stream: ByteStreamParser, context: CommandContext):
         root = stream.read_bytes(32)
         tree_size = stream.read_varint()
         leaf_index = stream.read_varint()
@@ -372,8 +372,8 @@ class GetMerkleLeafProofClientCommandFormatter(ClientCommandFormatter):
         print(
             f"<= ⏸ GET_MERKLE_LEAF_PROOF(root={format_merkle_root(root, context)},tree_size={tree_size},leaf_index={leaf_index})")
 
-    @classmethod
-    def format_cmd_response(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_response(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         leaf_hash = stream.read_bytes(32)
         proof_length = stream.read_bytes(1)[0]
         n_proof_elements = stream.read_bytes(1)[0]
@@ -410,8 +410,8 @@ class GetMerkleLeafProofClientCommandFormatter(ClientCommandFormatter):
 class GetMerkleLeafIndexClientCommandFormatter(ClientCommandFormatter):
     code = ClientCommandCode.GET_MERKLE_LEAF_INDEX
 
-    @classmethod
-    def format_cmd_request(cls, response: bytes, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_request(response: bytes, stream: ByteStreamParser, context: CommandContext):
         root = stream.read_bytes(32)
         leaf_hash = stream.read_bytes(32)
         stream.assert_empty()
@@ -419,8 +419,8 @@ class GetMerkleLeafIndexClientCommandFormatter(ClientCommandFormatter):
         print(
             f"<= ⏸ GET_MERKLE_LEAF_INDEX(root={format_merkle_root(root, context)},leaf_hash={format_hash_image(leaf_hash, context)})")
 
-    @classmethod
-    def format_cmd_response(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_response(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         found = stream.read_bytes(1)[0]
         assert 0 <= found <= 1
         leaf_index = stream.read_varint()
@@ -430,13 +430,13 @@ class GetMerkleLeafIndexClientCommandFormatter(ClientCommandFormatter):
 class GetMoreElementsClientCommandFormatter(ClientCommandFormatter):
     code = ClientCommandCode.GET_MORE_ELEMENTS
 
-    @classmethod
-    def format_cmd_request(cls, response: bytes, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_request(response: bytes, stream: ByteStreamParser, context: CommandContext):
         stream.assert_empty()
         print(f"<= ⏸ GET_MORE_ELEMENTS()")
 
-    @classmethod
-    def format_cmd_response(cls, apdu: APDU, stream: ByteStreamParser, context: CommandContext):
+    @staticmethod
+    def format_cmd_response(apdu: APDU, stream: ByteStreamParser, context: CommandContext):
         n_elems = stream.read_bytes(1)[0]
         elem_len = stream.read_bytes(1)[0]
         elements = [stream.read_bytes(elem_len)

--- a/doc/bitcoin.md
+++ b/doc/bitcoin.md
@@ -309,7 +309,7 @@ The signature is returned as a 65-byte binary string (1 byte equal to 32 or 33, 
 
 #### Description
 
-The digest being signed is the double-SHA256 of the message, after prefix ing the message with:
+The digest being signed is the double-SHA256 of the message, after prefixing the message with:
 
 - the magic string `"\x18Bitcoin Signed Message:\n"` (equal to `18426974636f696e205369676e6564204d6573736167653a0a` in hexadecimal)
 - the length of the message, encoded as a Bitcoin-style variable length integer.

--- a/src/commands.h
+++ b/src/commands.h
@@ -7,6 +7,7 @@
 #include "handler/get_wallet_address.h"
 #include "handler/register_wallet.h"
 #include "handler/sign_psbt.h"
+#include "handler/sign_message.h"
 
 /**
  * Enumeration with expected INS of APDU commands.
@@ -17,6 +18,7 @@ typedef enum {
     GET_WALLET_ADDRESS = 0x03,
     SIGN_PSBT = 0x04,
     GET_MASTER_FINGERPRINT = 0x05,
+    SIGN_MESSAGE = 0x10,
 } command_e;
 
 /**
@@ -28,6 +30,7 @@ typedef union {
     register_wallet_state_t register_wallet_state;
     get_wallet_address_state_t get_wallet_address_state;
     sign_psbt_state_t sign_psbt_state;
+    sign_message_state_t sign_message_state;
 } command_state_t;
 
 /**

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -272,9 +272,9 @@ uint32_t crypto_get_master_key_fingerprint();
  * Computes the base58check-encoded extended pubkey at a given path.
  *
  * @param[in]  bip32_path
- *   Pointer to 32-bit integer input buffer.
+ *   Pointer to 32-bit array of BIP-32 derivation steps.
  * @param[in]  bip32_path_len
- *   Number of BIP32 paths in the input buffer.
+ *   Number of steps in the BIP32 derivation.
  * @param[in]  bip32_pubkey_version
  *   Version prefix to use for the pubkey.
  * @param[out] out
@@ -322,7 +322,39 @@ void crypto_derive_symmetric_key(const char *label, size_t label_len, uint8_t ke
 int base58_encode_address(const uint8_t in[20], uint32_t version, char *out, size_t out_len);
 
 /**
- * TODO: docs
+ * Signs a SHA-256 hash using the ECDSA with deterministic nonce accordin to RFC6979; the signing
+ * private key is the one derived at the given BIP-32 path. The signature is returned in the
+ * conventional DER encoding.
+ *
+ * @param[in]  bip32_path
+ *   Pointer to 32-bit array of BIP-32 derivation steps.
+ * @param[in]  bip32_path_len
+ *   Number of steps in the BIP32 derivation.
+ * @param[in]  hash
+ *   Pointer to a 32-byte SHA-256 hash digest.
+ * @param[out]  out
+ *   The pointer to the output array to contain the signature, that must be of length
+ * `MAX_DER_SIG_LEN`.
+ * @param[out]  info
+ *   Pointer to contain the `info` variable returned by `cx_ecdsa_sign`, or `NULL` if not needed.
+ *
+ * @return the length of the signature on success, or -1 in case of error.
+ */
+int crypto_ecdsa_sign_sha256_hash_with_key(const uint32_t bip32_path[],
+                                           size_t bip32_path_len,
+                                           const uint8_t hash[static 32],
+                                           uint8_t out[static MAX_DER_SIG_LEN],
+                                           uint32_t *info);
+
+/**
+ * Initializes the "tagged" SHA256 hash with the given tag, as defined by BIP-0340.
+ *
+ * @param[out]  hash_context
+ *   Pointer to 32-bit array of BIP-32 derivation steps.
+ * @param[in]  tag
+ *   Pointer to an array containing the tag of the tagged hash.
+ * @param[in]  tag_len
+ *   Length of the tag.
  */
 void crypto_tr_tagged_hash_init(cx_sha256_t *hash_context, const uint8_t *tag, uint16_t tag_len);
 

--- a/src/handler/sign_message.c
+++ b/src/handler/sign_message.c
@@ -1,0 +1,186 @@
+/*****************************************************************************
+ *   Ledger App Bitcoin.
+ *   (c) 2021 Ledger SAS.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *****************************************************************************/
+
+#include <stdint.h>
+
+#include "boilerplate/io.h"
+#include "boilerplate/dispatcher.h"
+#include "boilerplate/sw.h"
+#include "../commands.h"
+#include "../constants.h"
+#include "../crypto.h"
+#include "../ui/display.h"
+#include "../ui/menu.h"
+
+extern global_context_t *G_coin_config;
+
+static void ui_action_accept_signing(dispatcher_context_t *dc, bool choice);
+
+static void send_response(dispatcher_context_t *dc);
+
+static unsigned char const BSM_SIGN_MAGIC[] = {'\x18', 'B', 'i', 't', 'c', 'o', 'i', 'n', ' ',
+                                               'S',    'i', 'g', 'n', 'e', 'd', ' ', 'M', 'e',
+                                               's',    's', 'a', 'g', 'e', ':', '\n'};
+
+void handler_sign_message(dispatcher_context_t *dc) {
+    sign_message_state_t *state = (sign_message_state_t *) &G_command_state;
+
+    LOG_PROCESSOR(dc, __FILE__, __LINE__, __func__);
+
+    // Device must be unlocked
+    if (os_global_pin_is_validated() != BOLOS_UX_OK) {
+        SEND_SW(dc, SW_SECURITY_STATUS_NOT_SATISFIED);
+        return;
+    }
+
+    if (!buffer_read_u8(&dc->read_buffer, &state->bip32_path_len) ||
+        !buffer_read_bip32_path(&dc->read_buffer, state->bip32_path, state->bip32_path_len) ||
+        !buffer_read_varint(&dc->read_buffer, &state->message_length) ||
+        !buffer_read_bytes(&dc->read_buffer, state->message_merkle_root, 32)) {
+        SEND_SW(dc, SW_WRONG_DATA_LENGTH);
+        return;
+    }
+
+    if (state->bip32_path_len > MAX_BIP32_PATH_STEPS || state->message_length >= (1LL << 32)) {
+        SEND_SW(dc, SW_INCORRECT_DATA);
+        return;
+    }
+
+    char path_str[MAX_SERIALIZED_BIP32_PATH_LENGTH + 1] = "(Master key)";
+    if (state->bip32_path_len > 0) {
+        bip32_path_format(state->bip32_path, state->bip32_path_len, path_str, sizeof(path_str));
+    }
+
+    cx_sha256_init(&state->msg_hash_context);
+    cx_sha256_init(&state->bsm_digest_context);
+
+    crypto_hash_update(&state->bsm_digest_context.header, BSM_SIGN_MAGIC, sizeof(BSM_SIGN_MAGIC));
+    crypto_hash_update_varint(&state->bsm_digest_context.header, state->message_length);
+
+    size_t n_chunks = (state->message_length + 63) / 64;
+    for (unsigned int i = 0; i < n_chunks; i++) {
+        uint8_t message_chunk[64];
+        int chunk_len = call_get_merkle_leaf_element(dc,
+                                                     state->message_merkle_root,
+                                                     n_chunks,
+                                                     i,
+                                                     message_chunk,
+                                                     sizeof(message_chunk));
+
+        if (chunk_len < 0 || (chunk_len != 64 && i != n_chunks - 1)) {
+            SEND_SW(dc, SW_BAD_STATE);  // should never happen
+            return;
+        }
+
+        crypto_hash_update(&state->msg_hash_context.header, message_chunk, chunk_len);
+        crypto_hash_update(&state->bsm_digest_context.header, message_chunk, chunk_len);
+    }
+
+    crypto_hash_digest(&state->msg_hash_context.header, state->message_hash, 32);
+    crypto_hash_digest(&state->bsm_digest_context.header, state->bsm_digest, 32);
+    cx_hash_sha256(state->bsm_digest, 32, state->bsm_digest, 32);
+
+    char message_hash_str[64 + 1];
+    for (int i = 0; i < 32; i++) {
+        snprintf(message_hash_str + 2 * i, 3, "%02X", state->message_hash[i]);
+    }
+
+    dc->pause();
+    ui_display_message_hash(dc, path_str, message_hash_str, ui_action_accept_signing);
+}
+
+static void ui_action_accept_signing(dispatcher_context_t *dc, bool choice) {
+    LOG_PROCESSOR(dc, __FILE__, __LINE__, __func__);
+
+    if (choice) {
+        dc->next(send_response);
+    } else {
+        SEND_SW(dc, SW_DENY);
+    }
+
+    dc->run();
+}
+
+static void send_response(dispatcher_context_t *dc) {
+    sign_message_state_t *state = (sign_message_state_t *) &G_command_state;
+
+    LOG_PROCESSOR(dc, __FILE__, __LINE__, __func__);
+
+    cx_ecfp_private_key_t private_key = {0};
+    uint8_t chain_code[32] = {0};
+    uint32_t info = 0;
+
+    uint8_t sig[MAX_DER_SIG_LEN];
+
+    int sig_len = 0;
+    bool error = false;
+    BEGIN_TRY {
+        TRY {
+            crypto_derive_private_key(&private_key,
+                                      chain_code,
+                                      state->bip32_path,
+                                      state->bip32_path_len);
+            sig_len = cx_ecdsa_sign(&private_key,
+                                    CX_RND_RFC6979,
+                                    CX_SHA256,
+                                    state->bsm_digest,
+                                    32,
+                                    sig,
+                                    MAX_DER_SIG_LEN,
+                                    &info);
+        }
+        CATCH_ALL {
+            error = true;
+        }
+        FINALLY {
+            explicit_bzero(&private_key, sizeof(private_key));
+        }
+    }
+    END_TRY;
+
+    if (error) {
+        // unexpected error when signing
+        SEND_SW(dc, SW_BAD_STATE);
+        return;
+    }
+
+    // convert signature to the standard Bitcoin format, always 65 bytes long
+
+    uint8_t result[65];
+    memset(result, 0, sizeof(result));
+
+    // # Format signature into standard bitcoin format
+    int r_length = sig[3];
+    int s_length = sig[4 + r_length + 1];
+
+    if (r_length > 33 || s_length > 33) {
+        SEND_SW(dc, SW_BAD_STATE);  // can never happen
+        return;
+    }
+
+    // Write s, r, and the first byte in reverse order, as the two loops will underflow by 1 byte
+    // (that needs to be discarded) when s_length and r_length (respectively) are equal to 33.
+    for (int i = s_length - 1; i >= 0; --i) {
+        result[1 + 32 + 32 - s_length + i] = sig[4 + r_length + 2 + i];
+    }
+    for (int i = r_length - 1; i >= 0; --i) {
+        result[1 + 32 - r_length + i] = sig[4 + i];
+    }
+    result[0] = 27 + 4 + ((info & CX_ECCINFO_PARITY_ODD) ? 1 : 0);
+
+    SEND_RESPONSE(dc, result, sizeof(result), SW_OK);
+}

--- a/src/handler/sign_message.h
+++ b/src/handler/sign_message.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../common/bip32.h"
+#include "../boilerplate/dispatcher.h"
+
+typedef struct {
+    machine_context_t ctx;
+
+    uint8_t bip32_path_len;
+    uint32_t bip32_path[MAX_BIP32_PATH_STEPS];
+    uint64_t message_length;
+    uint8_t message_merkle_root[32];
+
+    cx_sha256_t msg_hash_context;    // used to compute sha256(message)
+    cx_sha256_t bsm_digest_context;  // used to compute the Bitcoin Message Signing digest
+
+    uint8_t message_hash[32];
+    uint8_t bsm_digest[32];
+} sign_message_state_t;
+
+void handler_sign_message(dispatcher_context_t *dispatcher_context);

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -1963,10 +1963,6 @@ static void sign_sighash_ecdsa(dispatcher_context_t *dc) {
 
     LOG_PROCESSOR(dc, __FILE__, __LINE__, __func__);
 
-    cx_ecfp_private_key_t private_key = {0};
-    uint8_t chain_code[32] = {0};
-    uint32_t info = 0;
-
     uint32_t sign_path[MAX_BIP32_PATH_STEPS];
     for (int i = 0; i < state->our_key_derivation_length; i++) {
         sign_path[i] = state->our_key_derivation[i];
@@ -1978,30 +1974,9 @@ static void sign_sighash_ecdsa(dispatcher_context_t *dc) {
 
     uint8_t sig[MAX_DER_SIG_LEN];
 
-    int sig_len = 0;
-    bool error = false;
-    BEGIN_TRY {
-        TRY {
-            crypto_derive_private_key(&private_key, chain_code, sign_path, sign_path_len);
-            sig_len = cx_ecdsa_sign(&private_key,
-                                    CX_RND_RFC6979,
-                                    CX_SHA256,
-                                    state->sighash,
-                                    32,
-                                    sig,
-                                    MAX_DER_SIG_LEN,
-                                    &info);
-        }
-        CATCH_ALL {
-            error = true;
-        }
-        FINALLY {
-            explicit_bzero(&private_key, sizeof(private_key));
-        }
-    }
-    END_TRY;
-
-    if (error) {
+    int sig_len =
+        crypto_ecdsa_sign_sha256_hash_with_key(sign_path, sign_path_len, state->sighash, sig, NULL);
+    if (sig_len < 0) {
         // unexpected error when signing
         SEND_SW(dc, SW_BAD_STATE);
         return;

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -2063,9 +2063,7 @@ static void sign_sighash_schnorr(dispatcher_context_t *dc) {
                                                           sig,
                                                           &sig_len);
             if (err != CX_OK) {
-                PRINTF("Signature error: %08X\n", err);
-                SEND_SW(dc, SW_BAD_STATE);
-                return;
+                error = true;
             }
         }
         CATCH_ALL {

--- a/src/main.c
+++ b/src/main.c
@@ -95,6 +95,11 @@ const command_descriptor_t COMMAND_DESCRIPTORS[] = {
         .ins = GET_MASTER_FINGERPRINT,
         .handler = (command_handler_t)handler_get_master_fingerprint
     },
+    {
+        .cla = CLA_APP,
+        .ins = SIGN_MESSAGE,
+        .handler = (command_handler_t)handler_sign_message
+    },
 };
 // clang-format on
 

--- a/src/ui/display.h
+++ b/src/ui/display.h
@@ -23,6 +23,11 @@ void ui_display_pubkey(dispatcher_context_t *dispatcher_context,
                        action_validate_cb callback);
 
 // TODO: docs
+void ui_display_message_hash(dispatcher_context_t *context,
+                             char *bip32_path_str,
+                             char *message_hash,
+                             action_validate_cb callback);
+
 void ui_display_address(dispatcher_context_t *dispatcher_context,
                         char *address,
                         bool is_path_suspicious,

--- a/tests/automations/sign_message_accept.json
+++ b/tests/automations/sign_message_accept.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "regexp": "Path|Message hash",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Sign",
+      "conditions": [
+        [ "seen", false ]
+      ],
+      "actions": [
+        ["setbool", "seen", true],
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Sign",
+      "conditions": [
+        [ "seen", true ]
+      ],
+      "actions": [
+        ["setbool", "seen", true],
+        [ "button", 1, true ],
+        [ "button", 2, true ],
+        [ "button", 2, false ],
+        [ "button", 1, false ]
+      ]
+    }
+  ]
+}

--- a/tests/automations/sign_message_reject.json
+++ b/tests/automations/sign_message_reject.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "regexp": "Sign|Path|Message hash|Approve",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Reject",
+      "actions": [
+        [ "button", 1, true ],
+        [ "button", 2, true ],
+        [ "button", 2, false ],
+        [ "button", 1, false ]
+      ]
+    }
+  ]
+}

--- a/tests/test_sign_message.py
+++ b/tests/test_sign_message.py
@@ -1,0 +1,30 @@
+
+from bitcoin_client.ledger_bitcoin.common import sha256
+
+from bitcoin_client.ledger_bitcoin import Client
+
+from .utils import automation
+
+
+@automation("automations/sign_message_accept.json")
+def test_sign_message_accept(client: Client):
+    message = "Hello world!"
+
+    res = client.sign_message(
+        message,
+        "m/84'/1'/0'/0/0"
+    )
+
+    assert res == 'IEOK4+JMK7FToR7XMzFCoAYh1nud1IKm9Wq3vXLSVk/lBay8rHCRp9bP6riyR5NDqXYyYf7cXgMQTHNz3SemwZI='
+
+
+@automation("automations/sign_message_accept.json")
+def test_sign_message_accept_long(client: Client):
+    message = "The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible."
+
+    res = client.sign_message(
+        message,
+        "m/84'/1'/0'/0/8"
+    )
+
+    assert res == 'H4frM6TYm5ty1MAf9o/Zz9Qiy3VEldAYFY91SJ/5nYMAZY1UUB97fiRjKW8mJit2+V4OCa1YCqjDqyFnD9Fw75k='

--- a/tests/test_sign_message.py
+++ b/tests/test_sign_message.py
@@ -1,9 +1,18 @@
-
-from bitcoin_client.ledger_bitcoin.common import sha256
+import pytest
 
 from bitcoin_client.ledger_bitcoin import Client
+from bitcoin_client.ledger_bitcoin.exception.errors import DenyError
 
 from .utils import automation
+
+
+@automation("automations/sign_message_accept.json")
+def test_sign_message(client: Client):
+    msg = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks."
+    path = "m/44'/1'/0'/0/0"
+    result = client.sign_message(msg, path)
+
+    assert result == "IOR4YRVlmJGMx+H7PgQvHzWAF0HAgrUggQeRdnoWKpypfaAberpvF+XbOCM5Cd/ljogNyU3w2OIL8eYCyZ6Ru2k="
 
 
 @automation("automations/sign_message_accept.json")
@@ -20,6 +29,8 @@ def test_sign_message_accept(client: Client):
 
 @automation("automations/sign_message_accept.json")
 def test_sign_message_accept_long(client: Client):
+    # Test with a long message that is split in multiple leaves in the Merkle tree
+
     message = "The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible."
 
     res = client.sign_message(
@@ -28,3 +39,9 @@ def test_sign_message_accept_long(client: Client):
     )
 
     assert res == 'H4frM6TYm5ty1MAf9o/Zz9Qiy3VEldAYFY91SJ/5nYMAZY1UUB97fiRjKW8mJit2+V4OCa1YCqjDqyFnD9Fw75k='
+
+
+@automation("automations/sign_message_reject.json")
+def test_sign_message_reject(client: Client):
+    with pytest.raises(DenyError):
+        client.sign_message("Anything", "m/44'/1'/0'/0/0")


### PR DESCRIPTION
This PR adds the last missing feature: Bitcoin Message signing, which allows the owner of a Bitcoin address to sign a message that anybody can verify.

It is a legacy feature that does not fully fit the generality and the approach of the new app: it only works smoothly for legacy P2PKH transactions, and was adapted by Electrum (I think) for segwit addresses. Nonetheless, it is an expected feature, and necessary for a complete integration with [bitcoin-core/HWI](https://github.com/bitcoin-core/HWI).
We might look at more general alternative like [BIP-0322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki) for future versions.

The old app only shows the message hash when signing. This version also shows the derivation path.
Showing the address would be a bit more convenient, but doesn't quite fit the design of the new app and would have required too much additional code.

Incidentally, this PR also fixes a small unrelated issue in handling exceptions in the Schnorr signing code.