### PR TITLE
Refactor policy script computation, and some size optimizations

### DIFF
--- a/src/handler/get_wallet_address.c
+++ b/src/handler/get_wallet_address.c
@@ -238,8 +238,7 @@ static void compute_address(dispatcher_context_t *dc) {
                                             state->wallet_header_n_keys,
                                             state->is_change,
                                             state->address_index,
-                                            &script_buf,
-                                            NULL);
+                                            &script_buf);
     if (script_len < 0) {
         SEND_SW(dc, SW_BAD_STATE);  // unexpected
         return;

--- a/src/handler/lib/get_merkle_leaf_element.c
+++ b/src/handler/lib/get_merkle_leaf_element.c
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "get_merkle_leaf_element.h"
+
+#include "get_merkle_leaf_hash.h"
+#include "get_merkle_preimage.h"
+
+int call_get_merkle_leaf_element(dispatcher_context_t *dispatcher_context,
+                                 const uint8_t merkle_root[static 32],
+                                 uint32_t tree_size,
+                                 uint32_t leaf_index,
+                                 uint8_t *out_ptr,
+                                 size_t out_ptr_len) {
+    // LOG_PROCESSOR(dispatcher_context, __FILE__, __LINE__, __func__);
+
+    uint8_t leaf_hash[32];
+
+    int res = call_get_merkle_leaf_hash(dispatcher_context,
+                                        merkle_root,
+                                        tree_size,
+                                        leaf_index,
+                                        leaf_hash);
+    if (res < 0) {
+        return res;
+    }
+    return call_get_merkle_preimage(dispatcher_context, leaf_hash, out_ptr, out_ptr_len);
+}

--- a/src/handler/lib/get_merkle_leaf_element.h
+++ b/src/handler/lib/get_merkle_leaf_element.h
@@ -2,29 +2,12 @@
 
 #include "../../boilerplate/dispatcher.h"
 
-#include "get_merkle_leaf_element.h"
-
-#include "get_merkle_leaf_hash.h"
-#include "get_merkle_preimage.h"
-
-// inlined to save a stack frame
-static inline int call_get_merkle_leaf_element(dispatcher_context_t *dispatcher_context,
-                                               const uint8_t merkle_root[static 32],
-                                               uint32_t tree_size,
-                                               uint32_t leaf_index,
-                                               uint8_t *out_ptr,
-                                               size_t out_ptr_len) {
-    // LOG_PROCESSOR(dispatcher_context, __FILE__, __LINE__, __func__);
-
-    uint8_t leaf_hash[32];
-
-    int res = call_get_merkle_leaf_hash(dispatcher_context,
-                                        merkle_root,
-                                        tree_size,
-                                        leaf_index,
-                                        leaf_hash);
-    if (res < 0) {
-        return res;
-    }
-    return call_get_merkle_preimage(dispatcher_context, leaf_hash, out_ptr, out_ptr_len);
-}
+/**
+ * TODO: docs
+ */
+int call_get_merkle_leaf_element(dispatcher_context_t *dispatcher_context,
+                                 const uint8_t merkle_root[static 32],
+                                 uint32_t tree_size,
+                                 uint32_t leaf_index,
+                                 uint8_t *out_ptr,
+                                 size_t out_ptr_len);

--- a/src/handler/lib/get_merkle_leaf_index.h
+++ b/src/handler/lib/get_merkle_leaf_index.h
@@ -3,8 +3,7 @@
 #include "../../boilerplate/dispatcher.h"
 
 /**
- * Call the get_merkle_preimage flow.
- * TODO: more precise docs
+ * TODO: docs
  */
 int call_get_merkle_leaf_index(dispatcher_context_t *dispatcher_context,
                                size_t size,

--- a/src/handler/lib/policy.h
+++ b/src/handler/lib/policy.h
@@ -11,24 +11,55 @@
     (sizeof(WALLET_SLIP0021_LABEL) - 1)  // sizeof counts the terminating 0
 
 /**
- * TODO
+ * Computes the script corresponding to a wallet policy, for a certain change and address index.
+ *
+ * @param[in] dispatcher_context
+ *   Pointer to the dispatcher context
+ * @param[in] policy
+ *   Pointer to the root node of the policy
+ * @param[in] keys_merkle_root
+ *   The Merkle root of the tree of key informations in the policy
+ * @param[in] n_keys
+ *   The number of key information placeholders in the policy
+ * @param[in] change
+ *   0 for a receive address, 1 for a change address
+ * @param[in] address_index
+ *   The address index
+ * @param[in] out_buf
+ *   A buffer to contain the script. If the available space in the buffer is not enough, the result
+ * is truncated, but the correct length is still returned in case of success.
+ *
+ * @return The length of the output on success; -1 in case of error.
+ *
  */
 int call_get_wallet_script(dispatcher_context_t *dispatcher_context,
-                           policy_node_t *policy,
+                           const policy_node_t *policy,
                            const uint8_t keys_merkle_root[static 32],
                            uint32_t n_keys,
                            bool change,
                            size_t address_index,
-                           buffer_t *out_buf,
-                           cx_hash_t *hash_context);
+                           buffer_t *out_buf);
 
 /**
- * TODO
+ * Returns the address type constant corresponding to a standard policy type.
+ *
+ * @param[in] policy
+ *   Pointer to the root node of the policy
+ *
+ * @return One of, ADDRESS_TYPE_LEGACY, ADDRESS_TYPE_WIT, ADDRESS_TYPE_SH_WIT, ADDRESS_TYPE_TR if
+ * the policy pattern is one of the expected types; -1 otherwise.
  */
-int get_policy_address_type(policy_node_t *policy);
+int get_policy_address_type(const policy_node_t *policy);
 
 /**
  * Verifies if the wallet_hmac is correct for the given wallet_id, using the symmetric key derived
- * with the WALLET_SLIP0021_LABEL label according to SLIP-0021. Returns true/false accordingly.
+ * with the WALLET_SLIP0021_LABEL label according to SLIP-0021.
+ *
+ * @param[in] policy
+ *   Pointer to the root node of the policy
+ * @param[in] policy
+ *   Pointer to the root node of the policy
+
+ * @return true if the given hmac is valid, false otherwise.
  */
-bool check_wallet_hmac(uint8_t wallet_id[static 32], uint8_t wallet_hmac[static 32]);
+bool check_wallet_hmac(const uint8_t wallet_id[static 32], const uint8_t wallet_hmac[static 32]);

--- a/src/handler/sign_psbt/compare_wallet_script_at_path.c
+++ b/src/handler/sign_psbt/compare_wallet_script_at_path.c
@@ -28,8 +28,7 @@ int compare_wallet_script_at_path(dispatcher_context_t *dispatcher_context,
                                                    n_keys,
                                                    change,
                                                    address_index,
-                                                   &wallet_script_buf,
-                                                   NULL);
+                                                   &wallet_script_buf);
     if (wallet_script_len < 0) {
         PRINTF("Failed to get wallet script\n");
         return -1;  // shouldn't happen


### PR DESCRIPTION
Rewritten the code to compute the derived scripts from a policy; the new version is both smaller and uses less stack.

A few other optimizations to reduce the binary size are also included; most notably, avoiding `uint64_t` divisions in `display.c` saves >400 bytes in binary size.

Overall, this PR reduces the binary size from 63880 to 63112 bytes, or from 62.38 kb to 61.63 kb.