### PR TITLE
Added js library and initial set of tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - master
+    - develop
+  pull_request:
+    branches:
+    - master
+    - develop
 
 jobs:
   job_build:
@@ -146,7 +155,44 @@ jobs:
         run: |
           cd tests_mainnet && pip install -r requirements.txt && PYTHONPATH=$PYTHONPATH:/speculos pytest
 
+  job_test_js_lib:
+    name: Tests with the JS library
+    needs: job_build
+    runs-on: ubuntu-latest
 
+    container:
+      image: ghcr.io/ledgerhq/speculos:latest
+      ports:
+        - 1234:1234
+        - 9999:9999
+        - 40000:40000
+        - 41000:41000
+        - 42000:42000
+        - 43000:43000
+      options: --entrypoint /bin/bash
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install yarn
+        run: |
+          npm install -g yarn
+
+      - name: Download Bitcoin Testnet app binary
+        uses: actions/download-artifact@v2
+        with:
+          name: bitcoin-testnet-app
+          path: bin
+
+      - name: Run tests
+        run: |
+          cd bitcoin_client_js && yarn install && pwd && LOG_SPECULOS=1 LOG_APDUS=1 SPECULOS="/speculos/speculos.py" yarn test
 
   job_test_legacy_native:
     name: Legacy tests

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -1,6 +1,15 @@
 name: Code style check
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - master
+    - develop
+  pull_request:
+    branches:
+    - master
+    - develop
 
 jobs:
   job_lint:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,10 +1,16 @@
-name: Build
+name: Sonarcloud
+
 on:
   push:
     branches:
       - master
+      - develop
   pull_request:
+    branches:
+      - master
+      - develop
     types: [opened, synchronize, reopened]
+
 jobs:
   build:
     name: Build

--- a/bitcoin_client_js/.cspell.json
+++ b/bitcoin_client_js/.cspell.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.1",
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/master/cspell.schema.json",
+  "language": "en",
+  "words": [
+    "bitjson",
+    "bitauth",
+    "cimg",
+    "circleci",
+    "codecov",
+    "commitlint",
+    "dependabot",
+    "editorconfig",
+    "esnext",
+    "execa",
+    "exponentiate",
+    "globby",
+    "libauth",
+    "mkdir",
+    "prettierignore",
+    "sandboxed",
+    "transpiled",
+    "typedoc",
+    "untracked"
+  ],
+  "flagWords": [],
+  "ignorePaths": [
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "tsconfig.json",
+    "node_modules/**"
+  ]
+}

--- a/bitcoin_client_js/.editorconfig
+++ b/bitcoin_client_js/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/bitcoin_client_js/.eslintrc.json
+++ b/bitcoin_client_js/.eslintrc.json
@@ -1,0 +1,60 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "env": {
+    "es6": true
+  },
+  "ignorePatterns": [
+    "node_modules",
+    "build",
+    "coverage",
+    "**/__tests__/**"
+  ],
+  "plugins": [
+    "import",
+    "eslint-comments",
+    "jest"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:eslint-comments/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:import/typescript",
+    "prettier",
+    "prettier/@typescript-eslint"
+  ],
+  "globals": {
+    "BigInt": true,
+    "console": true,
+    "WebAssembly": true
+  },
+  "rules": {
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "eslint-comments/disable-enable-pair": [
+      "error",
+      {
+        "allowWholeFile": true
+      }
+    ],
+    "eslint-comments/no-unused-disable": "error",
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc"
+        }
+      }
+    ],
+    "sort-imports": [
+      "error",
+      {
+        "ignoreDeclarationSort": true,
+        "ignoreCase": true
+      }
+    ]
+  }
+}

--- a/bitcoin_client_js/.gitignore
+++ b/bitcoin_client_js/.gitignore
@@ -1,0 +1,9 @@
+.idea/*
+.nyc_output
+build
+node_modules
+test
+src/**.js
+coverage
+*.log
+yarn.lock

--- a/bitcoin_client_js/.prettierignore
+++ b/bitcoin_client_js/.prettierignore
@@ -1,0 +1,2 @@
+package.json
+**/__tests__/**

--- a/bitcoin_client_js/README.md
+++ b/bitcoin_client_js/README.md
@@ -1,0 +1,3 @@
+# ledger-bitcoin
+
+Ledger Hardware Wallet Bitcoin Application Client

--- a/bitcoin_client_js/README.md
+++ b/bitcoin_client_js/README.md
@@ -1,3 +1,113 @@
-# ledger-bitcoin
+# Ledger Bitcoin application client
 
-Ledger Hardware Wallet Bitcoin Application Client
+## Overview
+
+TypeScript client for Ledger Bitcoin application. Supports versions 2.0.0 and above of the app.
+
+Main repository and documentation: https://github.com/LedgerHQ/app-bitcoin-new
+
+<!--
+## Install
+
+TODO: fill this once the module is published
+-->
+
+## Building
+
+```bash
+$ yarn
+
+$ yarn build
+```
+
+## Getting started
+
+The following example showcases all the main methods of the `Client`'s interface.
+
+Testing the `signPsbt` method requires a valid PSBTv2, and provide the corresponding wallet policy; it is skipped by default in the following example.
+
+```javascript
+import { AppClient, DefaultWalletPolicy, WalletPolicy, PsbtV2 } from 'ledger-bitcoin';
+import Transport from '@ledgerhq/hw-transport-node-hid';
+
+// This examples assumes the Bitcoin Testnet app is running.
+// Make sure to use addresses compatible with mainnet otherwise, by using paths where the BIP-44 coin_type
+// is "0'" and not "1'".
+
+async function main(transport) {
+    const app = new AppClient(transport);
+
+    // ==> Get the master key fingerprint
+    const fpr = await app.getMasterFingerprint();
+    console.log("Master key fingerprint:", fpr.toString("hex"));
+
+    // ==> Get and display on screen the first taproot address
+    const firstTaprootAccountPubkey = await app.getExtendedPubkey("m/86'/1'/0'");
+    const firstTaprootAccountPolicy = new DefaultWalletPolicy(
+        "tr(@0)",
+        `[${fpr}/86'/1'/0']${firstTaprootAccountPubkey}/**`
+    );
+
+    const firstTaprootAccountAddress = await app.getWalletAddress(
+        firstTaprootAccountPolicy,
+        null,
+        0,
+        0,
+        true // show address on the wallet's screen
+    );
+
+    console.log("First taproot account receive address:", firstTaprootAccountAddress);
+
+    // ==> Register a multisig wallet named "Cold storage"
+
+    const ourPubkey = await app.getExtendedPubkey("m/48'/1'/0'/2'");
+    const ourKeyInfo = `[${fpr}/48'/1'/0'/2']${ourPubkey}/**`;
+    const otherKeyInfo = "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/**";
+
+    const multisigPolicy = new WalletPolicy(
+        "Cold storage",
+        "wsh(sortedmulti(2,@0,@1))", // a 2-of-2 multisig policy template
+        [
+            otherKeyInfo, // some other bitcoiner
+            ourKeyInfo,   // that's us
+        ]
+    )
+
+    const [policyId, policyHmac] = await app.registerWallet(multisigPolicy);
+
+    console.log(`Policy hmac: ${policyHmac.toString("hex")}. Store it safely (together with the policy).`);
+
+    console.assert(policyId.compare(multisigPolicy.getId()) == 0)  //  should never fail
+
+    // ==> Derive and show an address for "Cold storage" that was just registered
+
+    const multisigAddress = await app.getWalletAddress(multisigPolicy, policyHmac, 0, 0, true);
+    console.log(`Multisig wallet address: ${multisigAddress}`);
+
+    // ==> Sign a psbt
+
+    // TODO: set a wallet policy and a valid psbt file in order to test psbt signing
+    const rawPsbtBase64 = null; // a base64-encoded psbt file to sign
+    const signingPolicy = null; // an instance of WalletPolicy
+    const signingPolicyHmac = null; // if not a default wallet policy, this must also be set
+    if (!rawPsbtBase64 || !signingPolicy) {
+        console.log("Nothing to sign :(");
+        await transport.close();
+        return;
+    }
+
+    const psbt = new PsbtV2();
+    psbt.deserialize(rawPsbtBase64);
+
+    const result = await app.signPsbt(psbt, signingPolicy, signingPolicyHmac);
+
+    console.log("Returned signatures:");
+    console.log(result);
+
+    await transport.close();
+}
+
+Transport.default.create()
+    .then(main)
+    .catch(console.log);
+```

--- a/bitcoin_client_js/jest.config.js
+++ b/bitcoin_client_js/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/bitcoin_client_js/package.json
+++ b/bitcoin_client_js/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "ledger-bitcoin",
+  "version": "0.0.1",
+  "description": "Ledger Hardware Wallet Bitcoin Application Client",
+  "main": "build/main/index.js",
+  "typings": "build/main/index.d.ts",
+  "repository": "https://github.com/LedgerHW/app-bitcoin-new",
+  "license": "Apache-2.0",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "btc",
+    "Bitcoin",
+    "NanoS",
+    "NanoX",
+    "Hardware Wallet"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "fix": "run-s fix:*",
+    "fix:prettier": "prettier \"src/**/*.ts\" --write",
+    "fix:lint": "eslint src --ext .ts --fix",
+    "test": "jest --detectOpenHandles --verbose",
+    "doc": "run-s doc:html && open-cli build/docs/index.html",
+    "doc:html": "typedoc src/ --exclude **/*.test.ts --target ES6 --mode file --out build/docs",
+    "doc:json": "typedoc src/ --exclude **/*.test.ts --target ES6 --mode file --json build/docs/typedoc.json"
+  },
+  "engines": {
+    "node": ">=14"
+  },
+  "dependencies": {
+    "@ledgerhq/hw-transport": "^6.20.0",
+    "bip32-path": "^0.4.2",
+    "bitcoinjs-lib": "^6.0.1",
+    "tiny-secp256k1": "^2.1.2"
+  },
+  "devDependencies": {
+    "@ledgerhq/hw-transport-node-speculos-http": "^6.24.1",
+    "@ledgerhq/logs": "^6.10.0",
+    "@types/jest": "^27.4.0",
+    "@types/node": "^17.0.10",
+    "@typescript-eslint/eslint-plugin": "^4.0.1",
+    "@typescript-eslint/parser": "^4.0.1",
+    "codecov": "^3.5.0",
+    "cspell": "^4.1.0",
+    "eslint": "^7.8.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-functional": "^3.0.2",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-jest": "^26.1.1",
+    "jest": "^27.5.1",
+    "npm-run-all": "^4.1.5",
+    "open-cli": "^6.0.1",
+    "prettier": "^2.1.1",
+    "standard-version": "^9.0.0",
+    "ts-jest": "^27.1.3",
+    "ts-node": "^9.0.0",
+    "typedoc": "^0.19.0",
+    "typescript": "^4.5.5"
+  },
+  "files": [
+    "build/main",
+    "!**/*.spec.*",
+    "!**/*.test.*",
+    "!**/*.json",
+    "!**/__tests__/*",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "prettier": {
+    "singleQuote": true
+  }
+}

--- a/bitcoin_client_js/src/__tests__/appClient.test.ts
+++ b/bitcoin_client_js/src/__tests__/appClient.test.ts
@@ -1,0 +1,284 @@
+
+import fs from 'fs';
+import path from 'path';
+
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+
+import SpeculosTransport from "@ledgerhq/hw-transport-node-speculos-http";
+
+import type { SpeculosHttpTransportOpts } from "@ledgerhq/hw-transport-node-speculos-http";
+
+import { listen } from "@ledgerhq/logs";
+import type { Log } from "@ledgerhq/logs";
+
+
+import { AppClient, DefaultWalletPolicy, PsbtV2, WalletPolicy } from ".."
+
+jest.setTimeout(10000);
+
+
+/*
+This currently does not work if the app is compiled with DEBUG=1; this seems to be inherited from the fact that
+@ledgerhq/hw-transport-node-speculos-http seems to be malfunctioning in that case.
+
+The LOG_SPECULOS and LOG_APDUS environment variables can be used to log, respectively, the output of the speculos
+process and all the APDUs exchanged during the tests.
+*/
+
+
+const repoRootPath = path.resolve(process.cwd(), '..')
+
+const speculos_path = process.env.SPECULOS || "speculos.py";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function openSpeculosAndWait(opts: SpeculosHttpTransportOpts = {}): Promise<SpeculosTransport> {
+  for (let i = 0; ; i++) {
+    try {
+      return await SpeculosTransport.open(opts);
+    } catch (e) {
+      if (i > 50) {
+        throw e;
+      }
+    }
+    await sleep(100);
+  }
+}
+
+// Sets the speculos automation file using the REST api.
+// TODO: It would be better to add this in SpeculosTransport, or create a new custom class.
+async function setSpeculosAutomation(transport: SpeculosTransport, automationObj: any): Promise<void> {
+  return new Promise((resolve, reject) => {
+      transport.instance
+        .post(`/automation`, automationObj)
+        .then((response) => {
+          resolve(response.data);
+        }, reject);
+    });
+}
+
+// Hardened derivation
+function H(n: number) {
+  if (n < 0 || n >= 0x80000000) {
+    throw new Error("n should be non-negative and strictly smaller than 0x80000000")
+  }
+  return n + 0x80000000;
+}
+
+
+describe("test AppClient", () => {
+  let sp: ChildProcessWithoutNullStreams;
+  let transport: SpeculosTransport;
+  let app: AppClient;
+
+  beforeAll(async () => {
+    if (process.env.LOG_APDUS) {
+      listen((arg: Log) => {
+        if (arg.type == 'apdu') {
+          console.log("apdu:", arg.message);
+        }
+      });
+    }
+  });
+
+  beforeEach(async () => {
+    sp = spawn(speculos_path, [
+      repoRootPath + "/bin/app.elf",
+      '-k', '2.1',
+      '--display', 'headless'
+    ]);
+    
+    sp.stdout.on('data', function(data) {
+      if (process.env.LOG_SPECULOS) {
+        console.log('stdout: ' + data);
+      }
+    });
+
+    sp.stderr.on('data', function(data) {
+      if (process.env.LOG_SPECULOS) {
+        console.log('stderr: ' + data);
+      }
+    });
+
+    transport = await openSpeculosAndWait();
+    app = new AppClient(transport);
+  });
+
+  afterEach(async () => {
+    sp.kill('SIGTERM');
+  });
+
+
+  it("can retrieve the master fingerprint", async () => {
+    const result = await app.getMasterFingerprint();
+    expect(result).toEqual(Buffer.from("f5acc2fd", "hex"));
+  });
+
+  it("can get an extended pubkey", async () => {
+    const result = await app.getExtendedPubkey(
+      false, [H(49), H(1), H(1), 1, 3]
+    );
+
+    expect(result).toEqual("tpubDGnetmJDCL18TyaaoyRAYbkSE9wbHktSdTS4mfsR6inC8c2r6TjdBt3wkqEQhHYPtXpa46xpxDaCXU2PRNUGVvDzAHPG6hHRavYbwAGfnFr")
+  });
+
+  it("can get wallet addresses", async () => {
+    const testcases: {
+      policy: WalletPolicy,
+      change: 0 | 1,
+      addrIndex: number,
+      expResult: string,
+      walletHmac?: Buffer
+    }[] = [
+      // legacy
+      {
+        policy: new DefaultWalletPolicy("pkh(@0)", "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**"),
+        change: 0,
+        addrIndex: 0,
+        expResult: "mz5vLWdM1wHVGSmXUkhKVvZbJ2g4epMXSm",
+      },
+      {
+        policy: new DefaultWalletPolicy("pkh(@0)", "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**"),
+        change: 1,
+        addrIndex: 15,
+        expResult: "myFCUBRCKFjV7292HnZtiHqMzzHrApobpT",
+      },
+      // native segwit
+      {
+        policy: new DefaultWalletPolicy("wpkh(@0)", "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**"),
+        change: 0,
+        addrIndex: 0,
+        expResult: "tb1qzdr7s2sr0dwmkwx033r4nujzk86u0cy6fmzfjk",
+      },
+      {
+        policy: new DefaultWalletPolicy("wpkh(@0)", "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**"),
+        change: 1,
+        addrIndex: 15,
+        expResult: "tb1qlrvzyx8jcjfj2xuy69du9trtxnsvjuped7e289",
+      },
+      // wrapped segwit
+      {
+        policy: new DefaultWalletPolicy("sh(wpkh(@0))", "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3/**"),
+        change: 0,
+        addrIndex: 0,
+        expResult: "2MyHkbusvLomaarGYMqyq7q9pSBYJRwWcsw",
+      },
+      {
+        policy: new DefaultWalletPolicy("sh(wpkh(@0))", "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3/**"),
+        change: 1,
+        addrIndex: 15,
+        expResult: "2NAbM4FSeBQG4o85kbXw2YNfKypcnEZS9MR",
+      },
+      // taproot
+      {
+        policy: new DefaultWalletPolicy("tr(@0)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"),
+        change: 0,
+        addrIndex: 0,
+        expResult: "tb1pws8wvnj99ca6acf8kq7pjk7vyxknah0d9mexckh5s0vu2ccy68js9am6u7",
+      },
+      {
+        policy: new DefaultWalletPolicy("tr(@0)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"),
+        change: 0,
+        addrIndex: 9,
+        expResult: "tb1psl7eyk2jyjzq6evqvan854fts7a5j65rth25yqahkd2a765yvj0qggs5ne",
+      },
+      {
+        policy: new DefaultWalletPolicy("tr(@0)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"),
+        change: 1,
+        addrIndex: 0,
+        expResult: "tb1pmr60r5vfjmdkrwcu4a2z8h39mzs7a6wf2rfhuml6qgcp940x9cxs7t9pdy",
+      },
+      {
+        policy: new DefaultWalletPolicy("tr(@0)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"),
+        change: 1,
+        addrIndex: 9,
+        expResult: "tb1p98d6s9jkf0la8ras4nnm72zme5r03fexn29e3pgz4qksdy84ndpqgjak72",
+      },
+      // multisig
+      {
+        policy: new WalletPolicy(
+          "Cold storage",
+          "wsh(sortedmulti(2,@0,@1))",
+          [
+            "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/**",
+            "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK/**",
+          ]
+        ),
+        change: 0,
+        addrIndex: 0,
+        expResult: "tb1qmyauyzn08cduzdqweexgna2spwd0rndj55fsrkefry2cpuyt4cpsn2pg28",
+        walletHmac: Buffer.from("d6434852fb3caa7edbd1165084968f1691444b3cfc10cf1e431acbbc7f48451f", "hex")
+      },
+    ];
+
+    for (const { policy, change, addrIndex, expResult, walletHmac } of testcases) {
+      const result = await app.getWalletAddress(policy, walletHmac || null, change, addrIndex, false);
+      expect(result).toEqual(expResult);  
+    }
+  });
+
+
+  it("can register a multisig wallet", async () => {
+    const walletPolicy = new WalletPolicy(
+      "Cold storage",
+      "wsh(sortedmulti(2,@0,@1))",
+      [
+        "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/**",
+        "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK/**",
+      ]
+    );
+
+    const automation = JSON.parse(fs.readFileSync('src/__tests__/automations/register_wallet_accept.json').toString());
+    await setSpeculosAutomation(transport, automation);
+
+    const [walletId, walletHmac] = await app.registerWallet(walletPolicy);
+
+    expect(walletId).toEqual(walletPolicy.getWalletId());
+    expect(walletHmac.length).toEqual(32);
+  });
+
+  it("can sign a psbt", async () => {
+    // psbt from test_sign_psbt_singlesig_wpkh_2to2 in the main test suite, converted to PSBTv2
+    const psbtBuf = Buffer.from(
+      "cHNidP8BAAoBAAAAAAAAAAAAAQIEAgAAAAEDBAAAAAABBAECAQUBAgH7BAIAAAAAAQBxAgAAAAGTarLgEHL3k8/kyXdU3hth/gPn22U2yLLyHdC1dCxIRQEAAAAA/v///wLe4ccAAAAAABYAFOt418QL8QY7Dj/OKcNWW2ichVmrECcAAAAAAAAWABQjGNZvhP71xIdfkzsDjcY4MfjaE/mXHgABAR8QJwAAAAAAABYAFCMY1m+E/vXEh1+TOwONxjgx+NoTIgYDRV7nztyXsLpDW4AGb8ksljo0xgAxeYHRNTMMTuQ6x6MY9azC/VQAAIABAACAAAAAgAAAAAABAAAAAQ4gniz+J/Cth7eKI31ddAXUowZmyjYdWFpGew3+QiYrTbQBDwQBAAAAARAE/f///wESBAAAAAAAAQBxAQAAAAEORx706Sway1HvyGYPjT9pk26pybK/9y/5vIHFHvz0ZAEAAAAAAAAAAAJgrgoAAAAAABYAFDXG4N1tPISxa6iF3Kc6yGPQtZPsrwYyAAAAAAAWABTcKG4M0ua9N86+nsNJ+18IkFZy/AAAAAABAR9grgoAAAAAABYAFDXG4N1tPISxa6iF3Kc6yGPQtZPsIgYCcbW3ea2HCDhYd5e89vDHrsWr52pwnXJPSNLibPh08KAY9azC/VQAAIABAACAAAAAgAEAAAAAAAAAAQ4gr7+uBlkPdB/xr1m2rEYRJjNqTEqC21U99v76tzesM/MBDwQAAAAAARAE/f///wESBAAAAAAAIgICKexHcnEx7SWIogxG7amrt9qm9J/VC6/nC5xappYcTswY9azC/VQAAIABAACAAAAAgAEAAAAKAAAAAQMIqDoGAAAAAAABBBYAFOs4+puBKPgfJule2wxf+uqDaQ/kAAEDCOCTBAAAAAAAAQQiACA/qWbJ3c3C/ZbkpeG8dlufr2zos+tPEQSq1r33cyTlvgA=",
+      "base64"
+    );
+
+    const automation = JSON.parse(fs.readFileSync('src/__tests__/automations/sign_with_wallet_accept.json').toString());
+    await setSpeculosAutomation(transport, automation);
+
+    const walletPolicy = new DefaultWalletPolicy(
+      "wpkh(@0)",
+      "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**"
+    );
+
+    const psbt = new PsbtV2();
+    psbt.deserialize(psbtBuf);
+    const result = await app.signPsbt(psbt, walletPolicy, null, () => {});
+
+    expect(result.size).toEqual(2);
+    expect(result.get(0)).toEqual(Buffer.from(
+      "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01",
+      "hex"
+    ));
+    expect(result.get(1)).toEqual(Buffer.from(
+      "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001",
+      "hex"
+    ));
+  });
+
+  it("can sign a message", async () => {
+    const msg = "The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible.";
+    const path = [H(84), H(1), H(0), 0, 8];
+
+    const automation = JSON.parse(fs.readFileSync('src/__tests__/automations/sign_message_accept.json').toString());
+    await setSpeculosAutomation(transport, automation);
+
+    const result = await app.signMessage(Buffer.from(msg, "ascii"), path)
+    expect(result).toEqual("H4frM6TYm5ty1MAf9o/Zz9Qiy3VEldAYFY91SJ/5nYMAZY1UUB97fiRjKW8mJit2+V4OCa1YCqjDqyFnD9Fw75k=");
+  });
+});

--- a/bitcoin_client_js/src/__tests__/appClient.test.ts
+++ b/bitcoin_client_js/src/__tests__/appClient.test.ts
@@ -101,6 +101,8 @@ describe("test AppClient", () => {
   });
 
   afterEach(async () => {
+    await transport.close();
+    sp.removeAllListeners();
     sp.kill('SIGTERM');
   });
 

--- a/bitcoin_client_js/src/__tests__/appClient.test.ts
+++ b/bitcoin_client_js/src/__tests__/appClient.test.ts
@@ -61,14 +61,6 @@ async function setSpeculosAutomation(transport: SpeculosTransport, automationObj
     });
 }
 
-// Hardened derivation
-function H(n: number) {
-  if (n < 0 || n >= 0x80000000) {
-    throw new Error("n should be non-negative and strictly smaller than 0x80000000")
-  }
-  return n + 0x80000000;
-}
-
 
 describe("test AppClient", () => {
   let sp: ChildProcessWithoutNullStreams;
@@ -115,13 +107,11 @@ describe("test AppClient", () => {
 
   it("can retrieve the master fingerprint", async () => {
     const result = await app.getMasterFingerprint();
-    expect(result).toEqual(Buffer.from("f5acc2fd", "hex"));
+    expect(result).toEqual("f5acc2fd");
   });
 
   it("can get an extended pubkey", async () => {
-    const result = await app.getExtendedPubkey(
-      false, [H(49), H(1), H(1), 1, 3]
-    );
+    const result = await app.getExtendedPubkey("m/49'/1'/1'/1/3", false);
 
     expect(result).toEqual("tpubDGnetmJDCL18TyaaoyRAYbkSE9wbHktSdTS4mfsR6inC8c2r6TjdBt3wkqEQhHYPtXpa46xpxDaCXU2PRNUGVvDzAHPG6hHRavYbwAGfnFr")
   });
@@ -237,7 +227,7 @@ describe("test AppClient", () => {
 
     const [walletId, walletHmac] = await app.registerWallet(walletPolicy);
 
-    expect(walletId).toEqual(walletPolicy.getWalletId());
+    expect(walletId).toEqual(walletPolicy.getId());
     expect(walletHmac.length).toEqual(32);
   });
 
@@ -273,7 +263,7 @@ describe("test AppClient", () => {
 
   it("can sign a message", async () => {
     const msg = "The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible.";
-    const path = [H(84), H(1), H(0), 0, 8];
+    const path = "m/84'/1'/0'/0/8";
 
     const automation = JSON.parse(fs.readFileSync('src/__tests__/automations/sign_message_accept.json').toString());
     await setSpeculosAutomation(transport, automation);

--- a/bitcoin_client_js/src/__tests__/automations/register_wallet_accept.json
+++ b/bitcoin_client_js/src/__tests__/automations/register_wallet_accept.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "regexp": "Register wallet|Policy map|Key",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "text": "Approve",
+      "actions": [
+        [ "button", 1, true ],
+        [ "button", 2, true ],
+        [ "button", 2, false ],
+        [ "button", 1, false ]
+      ]
+    }
+  ]
+}

--- a/bitcoin_client_js/src/__tests__/automations/sign_message_accept.json
+++ b/bitcoin_client_js/src/__tests__/automations/sign_message_accept.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "regexp": "Path|Message hash",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Sign",
+      "conditions": [
+        [ "seen", false ]
+      ],
+      "actions": [
+        ["setbool", "seen", true],
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Sign",
+      "conditions": [
+        [ "seen", true ]
+      ],
+      "actions": [
+        ["setbool", "seen", true],
+        [ "button", 1, true ],
+        [ "button", 2, true ],
+        [ "button", 2, false ],
+        [ "button", 1, false ]
+      ]
+    }
+  ]
+}

--- a/bitcoin_client_js/src/__tests__/automations/sign_with_wallet_accept.json
+++ b/bitcoin_client_js/src/__tests__/automations/sign_with_wallet_accept.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "regexp": "Spend from|Review|Amount|Address|Confirm|Fees",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Approve|Accept",
+      "actions": [
+        [ "button", 1, true ],
+        [ "button", 2, true ],
+        [ "button", 2, false ],
+        [ "button", 1, false ]
+      ]
+    }
+  ]
+}

--- a/bitcoin_client_js/src/__tests__/varint.test.ts
+++ b/bitcoin_client_js/src/__tests__/varint.test.ts
@@ -1,0 +1,137 @@
+import { createVarint, parseVarint, sanitizeBigintToNumber } from "../lib/varint";
+
+describe("sanitizeBigintToNumber", () => {
+  it("throws for negative number", async () => {
+    expect(() => sanitizeBigintToNumber(BigInt(-1))).toThrow(RangeError);
+    expect(() => sanitizeBigintToNumber(-1)).toThrow(RangeError);
+  });
+
+  it("throws RangeError for number too large", async () => {
+    // Number.MAX_SAFE_INTEGER is 9007199254740991
+    expect(() => sanitizeBigintToNumber(Number.MAX_SAFE_INTEGER + 1)).toThrow(RangeError);
+    expect(() => sanitizeBigintToNumber(BigInt("9007199254740992"))).toThrow(RangeError);
+  });
+
+  it("correctly sanitizes biginters in range", async () => {
+    expect(sanitizeBigintToNumber(BigInt(0))).toEqual(0);
+    expect(sanitizeBigintToNumber(BigInt(1))).toEqual(1);
+    expect(sanitizeBigintToNumber(BigInt(Number.MAX_SAFE_INTEGER))).toEqual(Number.MAX_SAFE_INTEGER);
+
+    expect(sanitizeBigintToNumber(0)).toEqual(0);
+    expect(sanitizeBigintToNumber(1)).toEqual(1);
+    expect(sanitizeBigintToNumber(Number.MAX_SAFE_INTEGER)).toEqual(Number.MAX_SAFE_INTEGER);
+  });
+});
+
+
+describe("createVarint", () => {
+  it("correctly encodes 1-byte varints", async () => {
+    expect(createVarint(0)).toEqual(Buffer.from([0]));
+    expect(createVarint(BigInt(0))).toEqual(Buffer.from([0]));
+
+    expect(createVarint(1)).toEqual(Buffer.from([1]));
+    expect(createVarint(BigInt(1))).toEqual(Buffer.from([1]));
+
+    expect(createVarint(0xfc)).toEqual(Buffer.from([0xfc]));
+    expect(createVarint(BigInt(0xfc))).toEqual(Buffer.from([0xfc]));
+  });
+
+  it("correctly encodes 3-byte varints", async () => {
+    expect(createVarint(0xfd)).toEqual(Buffer.from([0xfd, 0xfd, 0x00]));
+    expect(createVarint(BigInt(0xfd))).toEqual(Buffer.from([0xfd, 0xfd, 0x00]));
+
+    expect(createVarint(0xffff)).toEqual(Buffer.from([0xfd, 0xff, 0xff]));
+    expect(createVarint(BigInt(0xffff))).toEqual(Buffer.from([0xfd, 0xff, 0xff]));
+  });
+
+  it("correctly encodes 5-byte varints", async () => {
+    expect(createVarint(0x00010000)).toEqual(Buffer.from([0xfe, 0x00, 0x00, 0x01, 0x00]));
+    expect(createVarint(BigInt(0x00010000))).toEqual(Buffer.from([0xfe, 0x00, 0x00, 0x01, 0x00]));
+
+    expect(createVarint(0x12345678)).toEqual(Buffer.from([0xfe, 0x78, 0x56, 0x34, 0x12]));
+    expect(createVarint(BigInt(0x12345678))).toEqual(Buffer.from([0xfe, 0x78, 0x56, 0x34, 0x12]));
+
+    expect(createVarint(0xffffffff)).toEqual(Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff]));
+    expect(createVarint(BigInt(0xffffffff))).toEqual(Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff]));
+  });
+
+  it("correctly encodes 9-byte varints", async () => {
+    expect(createVarint(0x100000000)).toEqual(Buffer.from([0xff, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]));
+    expect(createVarint(BigInt(0x100000000))).toEqual(
+      Buffer.from([0xff, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00])
+    );
+
+    expect(createVarint(BigInt("0x0011223344556677"))).toEqual(
+      Buffer.from([0xff, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00])
+    );
+
+    expect(createVarint(BigInt("0xffffffffffffffff"))).toEqual(
+      Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+    );
+  });
+
+  it("throws RangeError for values out of range", async () => {
+    expect(() => createVarint(-1)).toThrow(RangeError);
+    expect(() => createVarint(BigInt(-1))).toThrow(RangeError);
+    expect(() => createVarint(Number.MAX_SAFE_INTEGER + 1)).toThrow(RangeError);
+    expect(() => createVarint(BigInt("0x10000000000000000"))).toThrow(RangeError);
+  });
+});
+
+
+describe("parseVarint", () => {
+  const NIL = 42; // dummy value to label unused bytes
+
+  it("correctly decodes 1-byte varints", async () => {
+    expect(parseVarint(Buffer.from([0]), 0)).toEqual([BigInt(0), 1]);
+    expect(parseVarint(Buffer.from([NIL, 0]), 1)).toEqual([BigInt(0), 1]);
+
+    expect(parseVarint(Buffer.from([0xfc]), 0)).toEqual([BigInt(0xfc), 1]);
+  });
+
+  it("correctly decodes 3-byte varints", async () => {
+    expect(parseVarint(Buffer.from([0xfd, 0xfd, 0x00]), 0)).toEqual([BigInt(0xfd), 3]);
+    expect(parseVarint(Buffer.from([0xfd, 0xff, 0xff]), 0)).toEqual([BigInt(0xffff), 3]);
+  });
+
+  it("correctly decodes 5-byte varints", async () => {
+    expect(parseVarint(Buffer.from([0xfe, 0x00, 0x00, 0x01, 0x00]), 0)).toEqual([BigInt(0x00010000), 5]);
+    expect(parseVarint(Buffer.from([0xfe, 0x78, 0x56, 0x34, 0x12]), 0)).toEqual([BigInt(0x12345678), 5]);
+    expect(parseVarint(Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff]), 0)).toEqual([BigInt(0xffffffff), 5]);
+  });
+
+  it("correctly decodes 9-byte varints", async () => {
+    expect(parseVarint(Buffer.from([0xff, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]), 0)).toEqual(
+      [BigInt(0x100000000), 9]
+    );
+
+    expect(parseVarint(Buffer.from([0xff, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00]), 0)).toEqual(
+      [BigInt("0x0011223344556677"), 9]
+    );
+    expect(parseVarint(Buffer.from([NIL, 0xff, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00, NIL]), 1)).toEqual(
+      [BigInt("0x0011223344556677"), 9]
+    );
+    expect(parseVarint(Buffer.from([NIL, NIL, 0xff, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00]), 2)).toEqual(
+      [BigInt("0x0011223344556677"), 9]
+    );
+
+    expect(parseVarint(Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), 0)).toEqual(
+      [BigInt("0xffffffffffffffff"), 9]
+    );
+  });
+
+  it("throws RangeError if offset is negative", async () => {
+    expect(() => parseVarint(Buffer.from([0x12, 0x34]), -1)).toThrow(RangeError);
+  });
+
+  it("throws when the buffer is too small", async () => {
+    expect(() => parseVarint(Buffer.from([]), 0)).toThrow(Error);
+
+    expect(() => parseVarint(Buffer.from([0xfd, 0xff]), 0)).toThrow(Error);
+
+    expect(() => parseVarint(Buffer.from([0xfe, 0x78, 0x56, 0x34]), 0)).toThrow(Error);
+
+    expect(() => parseVarint(Buffer.from([NIL, NIL, 0xff, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11]), 2)).toThrow(Error);
+
+  });
+});

--- a/bitcoin_client_js/src/index.ts
+++ b/bitcoin_client_js/src/index.ts
@@ -1,0 +1,7 @@
+import AppClient from './lib/appClient';
+import { DefaultWalletPolicy, WalletPolicy } from './lib/policy';
+import { PsbtV2 } from './lib/psbtv2';
+
+export { AppClient, PsbtV2, DefaultWalletPolicy, WalletPolicy };
+
+export default AppClient;

--- a/bitcoin_client_js/src/lib/appClient.ts
+++ b/bitcoin_client_js/src/lib/appClient.ts
@@ -1,0 +1,251 @@
+import Transport from '@ledgerhq/hw-transport';
+
+import { pathElementsToBuffer } from './bip32';
+import { ClientCommandInterpreter } from './clientCommands';
+import { MerkelizedPsbt } from './merkelizedPsbt';
+import { hashLeaf, Merkle } from './merkle';
+import { WalletPolicy } from './policy';
+import { PsbtV2 } from './psbtv2';
+import { createVarint } from './varint';
+
+const CLA_BTC = 0xe1;
+const CLA_FRAMEWORK = 0xf8;
+
+enum BitcoinIns {
+  GET_PUBKEY = 0x00,
+  REGISTER_WALLET = 0x02,
+  GET_WALLET_ADDRESS = 0x03,
+  SIGN_PSBT = 0x04,
+  GET_MASTER_FINGERPRINT = 0x05,
+  SIGN_MESSAGE = 0x10,
+}
+
+enum FrameworkIns {
+  CONTINUE_INTERRUPTED = 0x01,
+}
+
+/**
+ * This class encapsulates the APDU protocol documented at
+ * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/bitcoin.md
+ */
+export class AppClient {
+  readonly transport: Transport;
+
+  constructor(transport: Transport) {
+    this.transport = transport;
+  }
+
+  private async makeRequest(
+    ins: BitcoinIns,
+    data: Buffer,
+    cci?: ClientCommandInterpreter
+  ): Promise<Buffer> {
+    let response: Buffer = await this.transport.send(
+      CLA_BTC,
+      ins,
+      0,
+      0,
+      data,
+      [0x9000, 0xe000]
+    );
+    while (response.readUInt16BE(response.length - 2) === 0xe000) {
+      if (!cci) {
+        throw new Error('Unexpected SW_INTERRUPTED_EXECUTION');
+      }
+
+      const hwRequest = response.slice(0, -2);
+      const commandResponse = cci.execute(hwRequest);
+
+      response = await this.transport.send(
+        CLA_FRAMEWORK,
+        FrameworkIns.CONTINUE_INTERRUPTED,
+        0,
+        0,
+        commandResponse,
+        [0x9000, 0xe000]
+      );
+    }
+    return response.slice(0, -2); // drop the status word (can only be 0x9000 at this point)
+  }
+
+  async getExtendedPubkey(
+    display: boolean,
+    pathElements: readonly number[]
+  ): Promise<string> {
+    if (pathElements.length > 6) {
+      throw new Error('Path too long. At most 6 levels allowed.');
+    }
+    const response = await this.makeRequest(
+      BitcoinIns.GET_PUBKEY,
+      Buffer.concat([
+        Buffer.from(display ? [1] : [0]),
+        pathElementsToBuffer(pathElements),
+      ])
+    );
+    return response.toString('ascii');
+  }
+
+  async registerWallet(
+    walletPolicy: WalletPolicy
+  ): Promise<readonly [Buffer, Buffer]> {
+    const serializedWalletPolicy = walletPolicy.serialize();
+
+    const clientInterpreter = new ClientCommandInterpreter();
+    clientInterpreter.addKnownPreimage(serializedWalletPolicy);
+    clientInterpreter.addKnownList(
+      walletPolicy.keys.map((k) => Buffer.from(k, 'ascii'))
+    );
+
+    const response = await this.makeRequest(
+      BitcoinIns.REGISTER_WALLET,
+      Buffer.concat([
+        createVarint(serializedWalletPolicy.length),
+        serializedWalletPolicy,
+      ]),
+      clientInterpreter
+    );
+
+    if (response.length != 64) {
+      throw Error(
+        `Invalid response length. Expected 64 bytes, got ${response.length}`
+      );
+    }
+
+    return [response.subarray(0, 32), response.subarray(32)];
+  }
+
+  async getWalletAddress(
+    walletPolicy: WalletPolicy,
+    walletHMAC: Buffer | null,
+    change: number,
+    addressIndex: number,
+    display: boolean
+  ): Promise<string> {
+    if (change !== 0 && change !== 1)
+      throw new Error('Change can only be 0 or 1');
+    if (addressIndex < 0 || !Number.isInteger(addressIndex))
+      throw new Error('Invalid address index');
+
+    if (walletHMAC != null && walletHMAC.length != 32) {
+      throw new Error('Invalid HMAC length');
+    }
+
+    const clientInterpreter = new ClientCommandInterpreter();
+    clientInterpreter.addKnownList(
+      walletPolicy.keys.map((k) => Buffer.from(k, 'ascii'))
+    );
+    clientInterpreter.addKnownPreimage(walletPolicy.serialize());
+
+    const addressIndexBuffer = Buffer.alloc(4);
+    addressIndexBuffer.writeUInt32BE(addressIndex, 0);
+
+    const response = await this.makeRequest(
+      BitcoinIns.GET_WALLET_ADDRESS,
+      Buffer.concat([
+        Buffer.from(display ? [1] : [0]),
+        walletPolicy.getWalletId(),
+        walletHMAC || Buffer.alloc(32, 0),
+        Buffer.from([change]),
+        addressIndexBuffer,
+      ]),
+      clientInterpreter
+    );
+
+    return response.toString('ascii');
+  }
+
+  async signPsbt(
+    psbt: PsbtV2,
+    walletPolicy: WalletPolicy,
+    walletHMAC: Buffer | null,
+    progressCallback?: () => void
+  ): Promise<Map<number, Buffer>> {
+    const merkelizedPsbt = new MerkelizedPsbt(psbt);
+
+    if (walletHMAC != null && walletHMAC.length != 32) {
+      throw new Error('Invalid HMAC length');
+    }
+
+    const clientInterpreter = new ClientCommandInterpreter(progressCallback);
+
+    // prepare ClientCommandInterpreter
+    clientInterpreter.addKnownList(
+      walletPolicy.keys.map((k) => Buffer.from(k, 'ascii'))
+    );
+    clientInterpreter.addKnownPreimage(walletPolicy.serialize());
+
+    clientInterpreter.addKnownMapping(merkelizedPsbt.globalMerkleMap);
+    for (const map of merkelizedPsbt.inputMerkleMaps) {
+      clientInterpreter.addKnownMapping(map);
+    }
+    for (const map of merkelizedPsbt.outputMerkleMaps) {
+      clientInterpreter.addKnownMapping(map);
+    }
+
+    clientInterpreter.addKnownList(merkelizedPsbt.inputMapCommitments);
+    const inputMapsRoot = new Merkle(
+      merkelizedPsbt.inputMapCommitments.map((m) => hashLeaf(m))
+    ).getRoot();
+    clientInterpreter.addKnownList(merkelizedPsbt.outputMapCommitments);
+    const outputMapsRoot = new Merkle(
+      merkelizedPsbt.outputMapCommitments.map((m) => hashLeaf(m))
+    ).getRoot();
+
+    await this.makeRequest(
+      BitcoinIns.SIGN_PSBT,
+      Buffer.concat([
+        merkelizedPsbt.getGlobalKeysValuesRoot(),
+        createVarint(merkelizedPsbt.getGlobalInputCount()),
+        inputMapsRoot,
+        createVarint(merkelizedPsbt.getGlobalOutputCount()),
+        outputMapsRoot,
+        walletPolicy.getWalletId(),
+        walletHMAC || Buffer.alloc(32, 0),
+      ]),
+      clientInterpreter
+    );
+
+    const yielded = clientInterpreter.getYielded();
+
+    const ret: Map<number, Buffer> = new Map();
+    for (const inputAndSig of yielded) {
+      ret.set(inputAndSig[0], inputAndSig.slice(1));
+    }
+    return ret;
+  }
+
+  async getMasterFingerprint(): Promise<Buffer> {
+    return this.makeRequest(BitcoinIns.GET_MASTER_FINGERPRINT, Buffer.from([]));
+  }
+
+  async signMessage(
+    message: Buffer,
+    pathElements: readonly number[]
+  ): Promise<string> {
+    const clientInterpreter = new ClientCommandInterpreter();
+
+    // prepare ClientCommandInterpreter
+    const nChunks = Math.ceil(message.length / 64);
+    const chunks: Buffer[] = [];
+    for (let i = 0; i < nChunks; i++) {
+      chunks.push(message.subarray(64 * i, 64 * i + 64));
+    }
+
+    clientInterpreter.addKnownList(chunks);
+    const chunksRoot = new Merkle(chunks.map((m) => hashLeaf(m))).getRoot();
+
+    const result = await this.makeRequest(
+      BitcoinIns.SIGN_MESSAGE,
+      Buffer.concat([
+        pathElementsToBuffer(pathElements),
+        createVarint(message.length),
+        chunksRoot,
+      ]),
+      clientInterpreter
+    );
+
+    return result.toString('base64');
+  }
+}
+
+export default AppClient;

--- a/bitcoin_client_js/src/lib/bip32.ts
+++ b/bitcoin_client_js/src/lib/bip32.ts
@@ -16,13 +16,18 @@ export function bip32asBuffer(path: string): Buffer {
 }
 
 export function pathArrayToString(pathElements: readonly number[]): string {
-  // Limitation: bippath can't handle and empty path. It shouldn't affect us
-  // right now, but might in the future.
-  // TODO: Fix support for empty path.
+  // bippath doesn't handle an empty path.
+  if (pathElements.length == 0) {
+    return "m";
+  }
   return bippath.fromPathArray(pathElements).toString();
 }
 
 export function pathStringToArray(path: string): readonly number[] {
+  // bippath doesn't handle an empty path.
+  if (path == "m" || path == "") {
+    return [];
+  }
   return bippath.fromString(path).toPathArray();
 }
 

--- a/bitcoin_client_js/src/lib/bip32.ts
+++ b/bitcoin_client_js/src/lib/bip32.ts
@@ -1,0 +1,56 @@
+import bippath from 'bip32-path'; // TODO: get rid of this dependency
+import bs58check from 'bs58check';
+
+export function pathElementsToBuffer(paths: readonly number[]): Buffer {
+  const buffer = Buffer.alloc(1 + paths.length * 4);
+  buffer[0] = paths.length;
+  paths.forEach((element, index) => {
+    buffer.writeUInt32BE(element, 1 + 4 * index);
+  });
+  return buffer;
+}
+
+export function bip32asBuffer(path: string): Buffer {
+  const pathElements = !path ? [] : pathStringToArray(path);
+  return pathElementsToBuffer(pathElements);
+}
+
+export function pathArrayToString(pathElements: readonly number[]): string {
+  // Limitation: bippath can't handle and empty path. It shouldn't affect us
+  // right now, but might in the future.
+  // TODO: Fix support for empty path.
+  return bippath.fromPathArray(pathElements).toString();
+}
+
+export function pathStringToArray(path: string): readonly number[] {
+  return bippath.fromString(path).toPathArray();
+}
+
+export function pubkeyFromXpub(xpub: string): Buffer {
+  const xpubBuf = bs58check.decode(xpub);
+  return xpubBuf.slice(xpubBuf.length - 33);
+}
+
+export function getXpubComponents(xpub: string): {
+  readonly chaincode: Buffer;
+  readonly pubkey: Buffer;
+  readonly version: number;
+} {
+  const xpubBuf: Buffer = bs58check.decode(xpub);
+  return {
+    chaincode: xpubBuf.slice(13, 13 + 32),
+    pubkey: xpubBuf.slice(xpubBuf.length - 33),
+    version: xpubBuf.readUInt32BE(0),
+  };
+}
+
+export function hardenedPathOf(
+  pathElements: readonly number[]
+): readonly number[] {
+  for (let i = pathElements.length - 1; i >= 0; i--) {
+    if (pathElements[i] >= 0x80000000) {
+      return pathElements.slice(0, i + 1);
+    }
+  }
+  return [];
+}

--- a/bitcoin_client_js/src/lib/buffertools.ts
+++ b/bitcoin_client_js/src/lib/buffertools.ts
@@ -1,4 +1,4 @@
-import { createVarint, parseVarint, sanitizeVarintToNumber } from './varint';
+import { createVarint, parseVarint, sanitizeBigintToNumber } from './varint';
 
 export function unsafeTo64bitLE(n: number): Buffer {
   // we want to represent the input as a 8-bytes array
@@ -121,7 +121,7 @@ export class BufferReader {
   }
 
   readVarSlice(): Buffer {
-    const n = sanitizeVarintToNumber(this.readVarInt());
+    const n = sanitizeBigintToNumber(this.readVarInt());
     return this.readSlice(n);
   }
 

--- a/bitcoin_client_js/src/lib/buffertools.ts
+++ b/bitcoin_client_js/src/lib/buffertools.ts
@@ -1,0 +1,134 @@
+import { createVarint, parseVarint, sanitizeVarintToNumber } from './varint';
+
+export function unsafeTo64bitLE(n: number): Buffer {
+  // we want to represent the input as a 8-bytes array
+  if (n > Number.MAX_SAFE_INTEGER) {
+    throw new Error("Can't convert numbers > MAX_SAFE_INT");
+  }
+  const byteArray = Buffer.alloc(8, 0);
+  for (let index = 0; index < byteArray.length; index++) {
+    const byte = n & 0xff;
+    byteArray[index] = byte;
+    n = (n - byte) / 256;
+  }
+  return byteArray;
+}
+
+export function unsafeFrom64bitLE(byteArray: Buffer): number {
+  let value = 0;
+  if (byteArray.length != 8) {
+    throw new Error('Expected Bufffer of lenght 8');
+  }
+  if (byteArray[7] != 0) {
+    throw new Error("Can't encode numbers > MAX_SAFE_INT");
+  }
+  if (byteArray[6] > 0x1f) {
+    throw new Error("Can't encode numbers > MAX_SAFE_INT");
+  }
+  for (let i = byteArray.length - 1; i >= 0; i--) {
+    value = value * 256 + byteArray[i];
+  }
+  return value;
+}
+
+export class BufferWriter {
+  private bufs: Buffer[] = [];
+
+  write(alloc: number, fn: (b: Buffer) => void): void {
+    const b = Buffer.alloc(alloc);
+    fn(b);
+    this.bufs.push(b);
+  }
+
+  writeUInt8(i: number): void {
+    this.write(1, (b) => b.writeUInt8(i, 0));
+  }
+
+  writeInt32(i: number): void {
+    this.write(4, (b) => b.writeInt32LE(i, 0));
+  }
+
+  writeUInt32(i: number): void {
+    this.write(4, (b) => b.writeUInt32LE(i, 0));
+  }
+
+  writeUInt64(i: number): void {
+    const bytes = unsafeTo64bitLE(i);
+    this.writeSlice(bytes);
+  }
+
+  writeVarInt(i: number): void {
+    this.bufs.push(createVarint(i));
+  }
+
+  writeSlice(slice: Buffer): void {
+    this.bufs.push(Buffer.from(slice));
+  }
+
+  writeVarSlice(slice: Buffer): void {
+    this.writeVarInt(slice.length);
+    this.writeSlice(slice);
+  }
+
+  buffer(): Buffer {
+    return Buffer.concat(this.bufs);
+  }
+}
+
+export class BufferReader {
+  constructor(public readonly buffer: Buffer, public offset: number = 0) {}
+
+  available(): number {
+    return this.buffer.length - this.offset;
+  }
+
+  readUInt8(): number {
+    const result = this.buffer.readUInt8(this.offset);
+    this.offset++;
+    return result;
+  }
+
+  readInt32(): number {
+    const result = this.buffer.readInt32LE(this.offset);
+    this.offset += 4;
+    return result;
+  }
+
+  readUInt32(): number {
+    const result = this.buffer.readUInt32LE(this.offset);
+    this.offset += 4;
+    return result;
+  }
+
+  readUInt64(): number {
+    const buf = this.readSlice(8);
+    return unsafeFrom64bitLE(buf);
+  }
+
+  readVarInt(): bigint {
+    const [vi, vi_size] = parseVarint(this.buffer, this.offset);
+    this.offset += vi_size;
+    return vi;
+  }
+
+  readSlice(n: number): Buffer {
+    if (this.buffer.length < this.offset + n) {
+      throw new Error('Cannot read slice out of bounds');
+    }
+    const result = this.buffer.slice(this.offset, this.offset + n);
+    this.offset += n;
+    return result;
+  }
+
+  readVarSlice(): Buffer {
+    const n = sanitizeVarintToNumber(this.readVarInt());
+    return this.readSlice(n);
+  }
+
+  readVector(): readonly Buffer[] {
+    const count = this.readVarInt();
+    const vector: Buffer[] = [];
+    for (let i = 0; i < count; i++) vector.push(this.readVarSlice());
+    return vector;
+  }
+}

--- a/bitcoin_client_js/src/lib/clientCommands.ts
+++ b/bitcoin_client_js/src/lib/clientCommands.ts
@@ -1,0 +1,340 @@
+import { crypto } from 'bitcoinjs-lib';
+
+import { BufferReader } from './buffertools';
+import { hashLeaf, Merkle } from './merkle';
+import { MerkleMap } from './merkleMap';
+import { createVarint, sanitizeVarintToNumber } from './varint';
+
+enum ClientCommandCode {
+  YIELD = 0x10,
+  GET_PREIMAGE = 0x40,
+  GET_MERKLE_LEAF_PROOF = 0x41,
+  GET_MERKLE_LEAF_INDEX = 0x42,
+  GET_MORE_ELEMENTS = 0xa0,
+}
+
+abstract class ClientCommand {
+  abstract code: ClientCommandCode;
+  abstract execute(request: Buffer): Buffer;
+}
+
+export class YieldCommand extends ClientCommand {
+  private results: Buffer[];
+
+  readonly code = ClientCommandCode.YIELD;
+
+  constructor(
+    results: Buffer[],
+    private readonly progressCallback?: () => void
+  ) {
+    super();
+    this.results = results;
+  }
+
+  execute(request: Buffer): Buffer {
+    this.results.push(Buffer.from(request.subarray(1)));
+    if (this.progressCallback) {
+      this.progressCallback();
+    }
+    return Buffer.from('');
+  }
+}
+
+export class GetPreimageCommand extends ClientCommand {
+  private readonly known_preimages: ReadonlyMap<string, Buffer>;
+  private queue: Buffer[];
+
+  readonly code = ClientCommandCode.GET_PREIMAGE;
+
+  constructor(known_preimages: ReadonlyMap<string, Buffer>, queue: Buffer[]) {
+    super();
+    this.known_preimages = known_preimages;
+    this.queue = queue;
+  }
+
+  execute(request: Buffer): Buffer {
+    const req = Buffer.from(request.subarray(1));
+
+    // we expect no more data to read
+    if (req.length != 1 + 32) {
+      throw new Error('Invalid request, unexpected trailing data');
+    }
+
+    if (req[0] != 0) {
+      throw new Error('Unsupported request, the first byte should be 0');
+    }
+
+    // read the hash
+    const hash = Buffer.alloc(32);
+    for (let i = 0; i < 32; i++) {
+      hash[i] = req[1 + i];
+    }
+    const req_hash_hex = hash.toString('hex');
+
+    const known_preimage = this.known_preimages.get(req_hash_hex);
+    if (known_preimage != undefined) {
+      const preimage_len_varint = createVarint(known_preimage.length);
+
+      // We can send at most 255 - len(preimage_len_out) - 1 bytes in a single message;
+      // the rest will be stored in the queue for GET_MORE_ELEMENTS
+      const max_payload_size = 255 - preimage_len_varint.length - 1;
+
+      const payload_size = Math.min(max_payload_size, known_preimage.length);
+
+      if (payload_size < known_preimage.length) {
+        for (let i = payload_size; i < known_preimage.length; i++) {
+          this.queue.push(Buffer.from([known_preimage[i]]));
+        }
+      }
+
+      return Buffer.concat([
+        preimage_len_varint,
+        Buffer.from([payload_size]),
+        Buffer.from(known_preimage.subarray(0, payload_size)),
+      ]);
+    }
+
+    throw Error(`Requested unknown preimage for: ${req_hash_hex}`);
+  }
+}
+
+export class GetMerkleLeafProofCommand extends ClientCommand {
+  private readonly known_trees: ReadonlyMap<string, Merkle>;
+  private queue: Buffer[];
+
+  readonly code = ClientCommandCode.GET_MERKLE_LEAF_PROOF;
+
+  constructor(known_trees: ReadonlyMap<string, Merkle>, queue: Buffer[]) {
+    super();
+    this.known_trees = known_trees;
+    this.queue = queue;
+  }
+
+  execute(request: Buffer): Buffer {
+    const req = Buffer.from(request.subarray(1));
+
+    if (req.length < 32 + 1 + 1) {
+      throw new Error('Invalid request, expected at least 34 bytes');
+    }
+
+    const reqBuf = new BufferReader(req);
+    const hash = reqBuf.readSlice(32);
+    const hash_hex = hash.toString('hex');
+
+    let tree_size: number;
+    let leaf_index: number;
+    try {
+      tree_size = sanitizeVarintToNumber(reqBuf.readVarInt());
+      leaf_index = sanitizeVarintToNumber(reqBuf.readVarInt());
+    } catch (e) {
+      throw new Error(
+        "Invalid request, couldn't parse tree_size or leaf_index"
+      );
+    }
+
+    const mt = this.known_trees.get(hash_hex);
+    if (!mt) {
+      throw Error(`Requested Merkle leaf proof for unknown tree: ${hash_hex}`);
+    }
+
+    if (leaf_index >= tree_size || mt.size() != tree_size) {
+      throw Error('Invalid index or tree size.');
+    }
+
+    if (this.queue.length != 0) {
+      throw Error(
+        'This command should not execute when the queue is not empty.'
+      );
+    }
+
+    const proof = mt.getProof(leaf_index);
+
+    const n_response_elements = Math.min(
+      Math.floor((255 - 32 - 1 - 1) / 32),
+      proof.length
+    );
+    const n_leftover_elements = proof.length - n_response_elements;
+
+    // Add to the queue any proof elements that do not fit the response
+    if (n_leftover_elements > 0) {
+      this.queue.push(...proof.slice(-n_leftover_elements));
+    }
+
+    return Buffer.concat([
+      mt.getLeafHash(leaf_index),
+      Buffer.from([proof.length]),
+      Buffer.from([n_response_elements]),
+      ...proof.slice(0, n_response_elements),
+    ]);
+  }
+}
+
+export class GetMerkleLeafIndexCommand extends ClientCommand {
+  private readonly known_trees: ReadonlyMap<string, Merkle>;
+
+  readonly code = ClientCommandCode.GET_MERKLE_LEAF_INDEX;
+
+  constructor(known_trees: ReadonlyMap<string, Merkle>) {
+    super();
+    this.known_trees = known_trees;
+  }
+
+  execute(request: Buffer): Buffer {
+    const req = Buffer.from(request.subarray(1));
+
+    if (req.length != 32 + 32) {
+      throw new Error('Invalid request, unexpected trailing data');
+    }
+
+    // read the root hash
+    const root_hash = Buffer.alloc(32);
+    for (let i = 0; i < 32; i++) {
+      root_hash[i] = req.readUInt8(i);
+    }
+    const root_hash_hex = root_hash.toString('hex');
+
+    // read the leaf hash
+    const leef_hash = Buffer.alloc(32);
+    for (let i = 0; i < 32; i++) {
+      leef_hash[i] = req.readUInt8(32 + i);
+    }
+    const leef_hash_hex = leef_hash.toString('hex');
+
+    const mt = this.known_trees.get(root_hash_hex);
+    if (!mt) {
+      throw Error(
+        `Requested Merkle leaf index for unknown root: ${root_hash_hex}`
+      );
+    }
+
+    let leaf_index = 0;
+    let found = 0;
+    for (let i = 0; i < mt.size(); i++) {
+      if (mt.getLeafHash(i).toString('hex') == leef_hash_hex) {
+        found = 1;
+        leaf_index = i;
+        break;
+      }
+    }
+    return Buffer.concat([Buffer.from([found]), createVarint(leaf_index)]);
+  }
+}
+
+export class GetMoreElementsCommand extends ClientCommand {
+  queue: Buffer[];
+
+  readonly code = ClientCommandCode.GET_MORE_ELEMENTS;
+
+  constructor(queue: Buffer[]) {
+    super();
+    this.queue = queue;
+  }
+
+  execute(request: Buffer): Buffer {
+    if (request.length != 1) {
+      throw new Error('Invalid request, unexpected trailing data');
+    }
+
+    if (this.queue.length === 0) {
+      throw new Error('No elements to get');
+    }
+
+    // all elements should have the same length
+    const element_len = this.queue[0].length;
+    if (this.queue.some((el) => el.length != element_len)) {
+      throw new Error(
+        'The queue contains elements with different byte length, which is not expected'
+      );
+    }
+
+    const max_elements = Math.floor(253 / element_len);
+    const n_returned_elements = Math.min(max_elements, this.queue.length);
+
+    const returned_elements = this.queue.splice(0, n_returned_elements);
+
+    return Buffer.concat([
+      Buffer.from([n_returned_elements]),
+      Buffer.from([element_len]),
+      ...returned_elements,
+    ]);
+  }
+}
+
+/**
+ * This class will dispatch a client command coming from the hardware device to
+ * the appropriate client command implementation. Those client commands
+ * typically requests data from a merkle tree or merkelized maps.
+ *
+ * A ClientCommandInterpreter is prepared by adding the merkle trees and
+ * merkelized maps it should be able to serve to the hardware device. This class
+ * doesn't know anything about the semantics of the data it holds, it just
+ * serves merkle data. It doesn't even know in what context it is being
+ * executed, ie SignPsbt, getWalletAddress, etc.
+ *
+ * If the command yelds results to the client, as signPsbt does, the yielded
+ * data will be accessible after the command completed by calling getYielded(),
+ * which will return the yields in the same order as they came in.
+ */
+export class ClientCommandInterpreter {
+  private readonly roots: Map<string, Merkle> = new Map();
+  private readonly preimages: Map<string, Buffer> = new Map();
+
+  private yielded: Buffer[] = [];
+
+  private queue: Buffer[] = [];
+
+  private readonly commands: Map<ClientCommandCode, ClientCommand> = new Map();
+
+  constructor(progressCallback?: () => void) {
+    const commands = [
+      new YieldCommand(this.yielded, progressCallback),
+      new GetPreimageCommand(this.preimages, this.queue),
+      new GetMerkleLeafIndexCommand(this.roots),
+      new GetMerkleLeafProofCommand(this.roots, this.queue),
+      new GetMoreElementsCommand(this.queue),
+    ];
+
+    for (const cmd of commands) {
+      if (this.commands.has(cmd.code)) {
+        throw new Error(`Multiple commands with code ${cmd.code}`);
+      }
+      this.commands.set(cmd.code, cmd);
+    }
+  }
+
+  getYielded(): readonly Buffer[] {
+    return this.yielded;
+  }
+
+  addKnownPreimage(preimage: Buffer): void {
+    this.preimages.set(crypto.sha256(preimage).toString('hex'), preimage);
+  }
+
+  addKnownList(elements: readonly Buffer[]): void {
+    for (const el of elements) {
+      const preimage = Buffer.concat([Buffer.from([0]), el]);
+      this.addKnownPreimage(preimage);
+    }
+    const mt = new Merkle(elements.map((el) => hashLeaf(el)));
+    this.roots.set(mt.getRoot().toString('hex'), mt);
+  }
+
+  addKnownMapping(mm: MerkleMap): void {
+    this.addKnownList(mm.keys);
+    this.addKnownList(mm.values);
+  }
+
+  execute(request: Buffer): Buffer {
+    if (request.length == 0) {
+      throw new Error('Unexpected empty command');
+    }
+
+    const cmdCode = request[0];
+    const cmd = this.commands.get(cmdCode);
+    if (!cmd) {
+      throw new Error(`Unexpected command code ${cmdCode}`);
+    }
+
+    return cmd.execute(request);
+  }
+}

--- a/bitcoin_client_js/src/lib/clientCommands.ts
+++ b/bitcoin_client_js/src/lib/clientCommands.ts
@@ -3,7 +3,7 @@ import { crypto } from 'bitcoinjs-lib';
 import { BufferReader } from './buffertools';
 import { hashLeaf, Merkle } from './merkle';
 import { MerkleMap } from './merkleMap';
-import { createVarint, sanitizeVarintToNumber } from './varint';
+import { createVarint, sanitizeBigintToNumber } from './varint';
 
 enum ClientCommandCode {
   YIELD = 0x10,
@@ -124,8 +124,8 @@ export class GetMerkleLeafProofCommand extends ClientCommand {
     let tree_size: number;
     let leaf_index: number;
     try {
-      tree_size = sanitizeVarintToNumber(reqBuf.readVarInt());
-      leaf_index = sanitizeVarintToNumber(reqBuf.readVarInt());
+      tree_size = sanitizeBigintToNumber(reqBuf.readVarInt());
+      leaf_index = sanitizeBigintToNumber(reqBuf.readVarInt());
     } catch (e) {
       throw new Error(
         "Invalid request, couldn't parse tree_size or leaf_index"

--- a/bitcoin_client_js/src/lib/constants.ts
+++ b/bitcoin_client_js/src/lib/constants.ts
@@ -1,0 +1,12 @@
+export const MAX_SCRIPT_BLOCK = 50;
+export const DEFAULT_VERSION = 1;
+export const DEFAULT_LOCKTIME = 0;
+export const DEFAULT_SEQUENCE = 0xffffffff;
+export const SIGHASH_ALL = 1;
+export const OP_DUP = 0x76;
+export const OP_HASH160 = 0xa9;
+export const HASH_SIZE = 0x14;
+export const OP_EQUAL = 0x87;
+export const OP_EQUALVERIFY = 0x88;
+export const OP_CHECKSIG = 0xac;
+export const OP_RETURN = 0x6a;

--- a/bitcoin_client_js/src/lib/merkelizedPsbt.ts
+++ b/bitcoin_client_js/src/lib/merkelizedPsbt.ts
@@ -1,0 +1,65 @@
+import { MerkleMap } from './merkleMap';
+import { PsbtV2 } from './psbtv2';
+
+/**
+ * This class merkelizes a PSBTv2, by merkelizing the different
+ * maps of the psbt. This is used during the transaction signing process,
+ * where the hardware app can request specific parts of the psbt from the
+ * client code and be sure that the response data actually belong to the psbt.
+ * The reason for this is the limited amount of memory available to the app,
+ * so it can't always store the full psbt in memory.
+ *
+ * The signing process is documented at
+ * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/bitcoin.md#sign_psbt
+ */
+export class MerkelizedPsbt extends PsbtV2 {
+  public readonly globalMerkleMap: MerkleMap;
+  public inputMerkleMaps: MerkleMap[] = [];
+  public outputMerkleMaps: MerkleMap[] = [];
+  public inputMapCommitments: Buffer[];
+  public outputMapCommitments: Buffer[];
+  constructor(psbt: PsbtV2) {
+    super();
+    psbt.copy(this);
+    this.globalMerkleMap = MerkelizedPsbt.createMerkleMap(this.globalMap);
+
+    for (let i = 0; i < this.getGlobalInputCount(); i++) {
+      this.inputMerkleMaps.push(
+        MerkelizedPsbt.createMerkleMap(this.inputMaps[i])
+      );
+    }
+    this.inputMapCommitments = [...this.inputMerkleMaps.values()].map((v) =>
+      v.commitment()
+    );
+
+    for (let i = 0; i < this.getGlobalOutputCount(); i++) {
+      this.outputMerkleMaps.push(
+        MerkelizedPsbt.createMerkleMap(this.outputMaps[i])
+      );
+    }
+    this.outputMapCommitments = [...this.outputMerkleMaps.values()].map((v) =>
+      v.commitment()
+    );
+  }
+  // These public functions are for MerkelizedPsbt.
+  getGlobalSize(): number {
+    return this.globalMap.size;
+  }
+  getGlobalKeysValuesRoot(): Buffer {
+    return this.globalMerkleMap.commitment();
+  }
+
+  private static createMerkleMap(map: ReadonlyMap<string, Buffer>): MerkleMap {
+    const sortedKeysStrings = [...map.keys()].sort();
+    const values = sortedKeysStrings.map((k) => {
+      const v = map.get(k);
+      if (!v) {
+        throw new Error('No value for key ' + k);
+      }
+      return v;
+    });
+    const sortedKeys = sortedKeysStrings.map((k) => Buffer.from(k, 'hex'));
+
+    return new MerkleMap(sortedKeys, values);
+  }
+}

--- a/bitcoin_client_js/src/lib/merkle.ts
+++ b/bitcoin_client_js/src/lib/merkle.ts
@@ -1,0 +1,131 @@
+import { crypto } from 'bitcoinjs-lib';
+
+/**
+ * This class implements the merkle tree used by Ledger Bitcoin app v2+,
+ * which is documented at
+ * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/merkle.md
+ */
+export class Merkle {
+  private leaves: Buffer[];
+  private rootNode: Node;
+  private leafNodes: Node[];
+  private h: (buf: Buffer) => Buffer;
+  constructor(
+    leaves: Buffer[],
+    hasher: (buf: Buffer) => Buffer = crypto.sha256
+  ) {
+    this.leaves = leaves;
+    this.h = hasher;
+    const nodes = this.calculateRoot(leaves);
+    this.rootNode = nodes.root;
+    this.leafNodes = nodes.leaves;
+  }
+  getRoot(): Buffer {
+    return this.rootNode.hash;
+  }
+  size(): number {
+    return this.leaves.length;
+  }
+  getLeaves(): Buffer[] {
+    return this.leaves;
+  }
+  getLeafHash(index: number): Buffer {
+    return this.leafNodes[index].hash;
+  }
+  getProof(index: number): Buffer[] {
+    if (index >= this.leaves.length) throw Error('Index out of bounds');
+    return proveNode(this.leafNodes[index]);
+  }
+
+  calculateRoot(leaves: Buffer[]): {
+    root: Node;
+    leaves: Node[];
+  } {
+    const n = leaves.length;
+    if (n == 0) {
+      return {
+        root: new Node(undefined, undefined, Buffer.alloc(32, 0)),
+        leaves: [],
+      };
+    }
+    if (n == 1) {
+      const newNode = new Node(undefined, undefined, leaves[0]);
+      return { root: newNode, leaves: [newNode] };
+    }
+    const leftCount = highestPowerOf2LessThan(n);
+    const leftBranch = this.calculateRoot(leaves.slice(0, leftCount));
+    const rightBranch = this.calculateRoot(leaves.slice(leftCount));
+    const leftChild = leftBranch.root;
+    const rightChild = rightBranch.root;
+    const hash = this.hashNode(leftChild.hash, rightChild.hash);
+    const node = new Node(leftChild, rightChild, hash);
+    leftChild.parent = node;
+    rightChild.parent = node;
+    return { root: node, leaves: leftBranch.leaves.concat(rightBranch.leaves) };
+  }
+
+  hashNode(left: Buffer, right: Buffer): Buffer {
+    return this.h(Buffer.concat([Buffer.from([1]), left, right]));
+  }
+}
+
+export function hashLeaf(
+  buf: Buffer,
+  hashFunction: (buf: Buffer) => Buffer = crypto.sha256
+): Buffer {
+  return hashConcat(Buffer.from([0]), buf, hashFunction);
+}
+
+function hashConcat(
+  bufA: Buffer,
+  bufB: Buffer,
+  hashFunction: (buf: Buffer) => Buffer
+): Buffer {
+  return hashFunction(Buffer.concat([bufA, bufB]));
+}
+
+class Node {
+  leftChild?: Node;
+  rightChild?: Node;
+  parent?: Node;
+  hash: Buffer;
+  constructor(left: Node | undefined, right: Node | undefined, hash: Buffer) {
+    this.leftChild = left;
+    this.rightChild = right;
+    this.hash = hash;
+  }
+  isLeaf(): boolean {
+    return this.leftChild == undefined;
+  }
+}
+
+function proveNode(node: Node): Buffer[] {
+  if (!node.parent) {
+    return [];
+  }
+  if (node.parent.leftChild == node) {
+    if (!node.parent.rightChild) {
+      throw new Error('Expected right child to exist');
+    }
+    return [node.parent.rightChild.hash, ...proveNode(node.parent)];
+  } else {
+    if (!node.parent.leftChild) {
+      throw new Error('Expected left child to exist');
+    }
+    return [node.parent.leftChild.hash, ...proveNode(node.parent)];
+  }
+}
+
+function highestPowerOf2LessThan(n: number) {
+  if (n < 2) {
+    throw Error('Expected n >= 2');
+  }
+  if (isPowerOf2(n)) {
+    return n / 2;
+  }
+  return 1 << Math.floor(Math.log2(n));
+}
+
+function isPowerOf2(n: number): boolean {
+  return (n & (n - 1)) == 0;
+}

--- a/bitcoin_client_js/src/lib/merkleMap.ts
+++ b/bitcoin_client_js/src/lib/merkleMap.ts
@@ -1,0 +1,49 @@
+import { hashLeaf, Merkle } from './merkle';
+import { createVarint } from './varint';
+
+/**
+ * This implements "Merkelized Maps", documented at
+ * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/merkle.md#merkleized-maps
+ *
+ * A merkelized map consist of two merkle trees, one for the keys of
+ * a map and one for the values of the same map, thus the two merkle
+ * trees have the same shape. The commitment is the number elements
+ * in the map followed by the keys' merkle root followed by the
+ * values' merkle root.
+ */
+export class MerkleMap {
+  readonly keys: readonly Buffer[];
+  readonly keysTree: Merkle;
+  readonly values: readonly Buffer[];
+  readonly valuesTree: Merkle;
+  /**
+   * @param keys Sorted list of (unhashed) keys
+   * @param values values, in corresponding order as the keys, and of equal length
+   */
+  constructor(keys: readonly Buffer[], values: readonly Buffer[]) {
+    if (keys.length != values.length) {
+      throw new Error('keys and values should have the same length');
+    }
+
+    // Sanity check: verify that keys are actually sorted and with no duplicates
+    for (let i = 0; i < keys.length - 1; i++) {
+      if (keys[i].toString('hex') >= keys[i + 1].toString('hex')) {
+        throw new Error('keys must be in strictly increasing order');
+      }
+    }
+
+    this.keys = keys;
+    this.keysTree = new Merkle(keys.map((k) => hashLeaf(k)));
+    this.values = values;
+    this.valuesTree = new Merkle(values.map((v) => hashLeaf(v)));
+  }
+
+  commitment(): Buffer {
+    // returns a buffer between 65 and 73 (included) bytes long
+    return Buffer.concat([
+      createVarint(this.keys.length),
+      this.keysTree.getRoot(),
+      this.valuesTree.getRoot(),
+    ]);
+  }
+}

--- a/bitcoin_client_js/src/lib/policy.ts
+++ b/bitcoin_client_js/src/lib/policy.ts
@@ -15,6 +15,12 @@ export class WalletPolicy {
   readonly name: string;
   readonly descriptorTemplate: string;
   readonly keys: readonly string[];
+  /**
+   * Creates and instance of a wallet policy.
+   * @param name an ascii string, up to 16 bytes long; it must be an empty string for default wallet policies
+   * @param descriptorTemplate the wallet policy template
+   * @param keys and array of the keys, with the key derivation information
+   */
   constructor(
     name: string,
     descriptorTemplate: string,
@@ -25,11 +31,17 @@ export class WalletPolicy {
     this.keys = keys;
   }
 
-  getWalletId(): Buffer {
-    // wallet_id (sha256 of the wallet serialization),
+  /**
+   * Returns the unique 32-bytes id of this wallet policy.
+   */
+  getId(): Buffer {
     return crypto.sha256(this.serialize());
   }
 
+  /**
+   * Serializes the wallet policy for transmission via the hardware wallet protocol.
+   * @returns the serialized wallet policy
+   */
   serialize(): Buffer {
     const keyBuffers = this.keys.map((k) => {
       return Buffer.from(k, 'ascii');
@@ -53,12 +65,7 @@ export type DefaultDescriptorTemplate =
   | 'tr(@0)';
 
 /**
- * The Bitcon hardware app uses a descriptors-like thing to describe
- * how to construct output scripts from keys. A "Wallet Policy" consists
- * of a "Descriptor Template" and a list of "keys". A key is basically
- * a serialized BIP32 extended public key with some added derivation path
- * information. This is documented at
- * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/wallet.md
+ * Simplified class to handle default wallet policies that can be used without policy registration.
  */
 export class DefaultWalletPolicy extends WalletPolicy {
   constructor(descriptorTemplate: DefaultDescriptorTemplate, key: string) {

--- a/bitcoin_client_js/src/lib/policy.ts
+++ b/bitcoin_client_js/src/lib/policy.ts
@@ -1,0 +1,67 @@
+import { crypto } from 'bitcoinjs-lib';
+
+import { BufferWriter } from './buffertools';
+import { hashLeaf, Merkle } from './merkle';
+
+/**
+ * The Bitcon hardware app uses a descriptors-like thing to describe
+ * how to construct output scripts from keys. A "Wallet Policy" consists
+ * of a "Descriptor Template" and a list of "keys". A key is basically
+ * a serialized BIP32 extended public key with some added derivation path
+ * information. This is documented at
+ * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/wallet.md
+ */
+export class WalletPolicy {
+  readonly name: string;
+  readonly descriptorTemplate: string;
+  readonly keys: readonly string[];
+  constructor(
+    name: string,
+    descriptorTemplate: string,
+    keys: readonly string[]
+  ) {
+    this.name = name;
+    this.descriptorTemplate = descriptorTemplate;
+    this.keys = keys;
+  }
+
+  getWalletId(): Buffer {
+    // wallet_id (sha256 of the wallet serialization),
+    return crypto.sha256(this.serialize());
+  }
+
+  serialize(): Buffer {
+    const keyBuffers = this.keys.map((k) => {
+      return Buffer.from(k, 'ascii');
+    });
+    const m = new Merkle(keyBuffers.map((k) => hashLeaf(k)));
+
+    const buf = new BufferWriter();
+    buf.writeUInt8(0x01); // wallet type (policy map)
+    buf.writeVarSlice(Buffer.from(this.name, 'ascii'));
+    buf.writeVarSlice(Buffer.from(this.descriptorTemplate, 'ascii'));
+    buf.writeVarInt(this.keys.length);
+    buf.writeSlice(m.getRoot());
+    return buf.buffer();
+  }
+}
+
+export type DefaultDescriptorTemplate =
+  | 'pkh(@0)'
+  | 'sh(wpkh(@0))'
+  | 'wpkh(@0)'
+  | 'tr(@0)';
+
+/**
+ * The Bitcon hardware app uses a descriptors-like thing to describe
+ * how to construct output scripts from keys. A "Wallet Policy" consists
+ * of a "Descriptor Template" and a list of "keys". A key is basically
+ * a serialized BIP32 extended public key with some added derivation path
+ * information. This is documented at
+ * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/wallet.md
+ */
+export class DefaultWalletPolicy extends WalletPolicy {
+  constructor(descriptorTemplate: DefaultDescriptorTemplate, key: string) {
+    super('', descriptorTemplate, [key]);
+  }
+}

--- a/bitcoin_client_js/src/lib/psbtv2.ts
+++ b/bitcoin_client_js/src/lib/psbtv2.ts
@@ -6,7 +6,7 @@ import {
   unsafeFrom64bitLE,
   unsafeTo64bitLE,
 } from './buffertools';
-import { sanitizeVarintToNumber } from './varint';
+import { sanitizeBigintToNumber } from './varint';
 
 export enum psbtGlobal {
   TX_VERSION = 0x02,
@@ -365,7 +365,7 @@ export class PsbtV2 {
     }
   }
   private readKeyPair(map: Map<string, Buffer>, buf: BufferReader): boolean {
-    const keyLen = sanitizeVarintToNumber(buf.readVarInt());
+    const keyLen = sanitizeBigintToNumber(buf.readVarInt());
     if (keyLen == 0) {
       return false;
     }
@@ -494,7 +494,7 @@ export class PsbtV2 {
     readonly path: readonly number[];
   } {
     const buf = new BufferReader(buffer);
-    const hashCount = sanitizeVarintToNumber(buf.readVarInt());
+    const hashCount = sanitizeBigintToNumber(buf.readVarInt());
     const hashes: Buffer[] = [];
     for (let i = 0; i < hashCount; i++) {
       hashes.push(buf.readSlice(32));
@@ -594,5 +594,5 @@ function varint(n: number): Buffer {
   return buf.buffer();
 }
 function fromVarint(buf: Buffer): number {
-  return sanitizeVarintToNumber(new BufferReader(buf).readVarInt());
+  return sanitizeBigintToNumber(new BufferReader(buf).readVarInt());
 }

--- a/bitcoin_client_js/src/lib/psbtv2.ts
+++ b/bitcoin_client_js/src/lib/psbtv2.ts
@@ -1,0 +1,598 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import {
+  BufferReader,
+  BufferWriter,
+  unsafeFrom64bitLE,
+  unsafeTo64bitLE,
+} from './buffertools';
+import { sanitizeVarintToNumber } from './varint';
+
+export enum psbtGlobal {
+  TX_VERSION = 0x02,
+  FALLBACK_LOCKTIME = 0x03,
+  INPUT_COUNT = 0x04,
+  OUTPUT_COUNT = 0x05,
+  TX_MODIFIABLE = 0x06,
+  VERSION = 0xfb,
+}
+export enum psbtIn {
+  NON_WITNESS_UTXO = 0x00,
+  WITNESS_UTXO = 0x01,
+  PARTIAL_SIG = 0x02,
+  SIGHASH_TYPE = 0x03,
+  REDEEM_SCRIPT = 0x04,
+  BIP32_DERIVATION = 0x06,
+  FINAL_SCRIPTSIG = 0x07,
+  FINAL_SCRIPTWITNESS = 0x08,
+  PREVIOUS_TXID = 0x0e,
+  OUTPUT_INDEX = 0x0f,
+  SEQUENCE = 0x10,
+  TAP_KEY_SIG = 0x13,
+  TAP_BIP32_DERIVATION = 0x16,
+}
+export enum psbtOut {
+  REDEEM_SCRIPT = 0x00,
+  BIP_32_DERIVATION = 0x02,
+  AMOUNT = 0x03,
+  SCRIPT = 0x04,
+  TAP_BIP32_DERIVATION = 0x07,
+}
+
+const PSBT_MAGIC_BYTES = Buffer.from([0x70, 0x73, 0x62, 0x74, 0xff]);
+
+export class NoSuchEntry extends Error {}
+
+/**
+ * Implements Partially Signed Bitcoin Transaction version 2, BIP370, as
+ * documented at https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki
+ * and https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+ *
+ * A psbt is a data structure that can carry all relevant information about a
+ * transaction through all stages of the signing process. From constructing an
+ * unsigned transaction to extracting the final serialized transaction ready for
+ * broadcast.
+ *
+ * This implementation is limited to what's needed in ledgerjs to carry out its
+ * duties, which means that support for features like multisig or taproot script
+ * path spending are not implemented. Specifically, it supports p2pkh,
+ * p2wpkhWrappedInP2sh, p2wpkh and p2tr key path spending.
+ *
+ * This class is made purposefully dumb, so it's easy to add support for
+ * complemantary fields as needed in the future.
+ */
+export class PsbtV2 {
+  protected globalMap: Map<string, Buffer> = new Map();
+  protected inputMaps: Map<string, Buffer>[] = [];
+  protected outputMaps: Map<string, Buffer>[] = [];
+
+  setGlobalTxVersion(version: number) {
+    this.setGlobal(psbtGlobal.TX_VERSION, uint32LE(version));
+  }
+  getGlobalTxVersion(): number {
+    return this.getGlobal(psbtGlobal.TX_VERSION).readUInt32LE(0);
+  }
+  setGlobalFallbackLocktime(locktime: number) {
+    this.setGlobal(psbtGlobal.FALLBACK_LOCKTIME, uint32LE(locktime));
+  }
+  getGlobalFallbackLocktime(): number | undefined {
+    return this.getGlobalOptional(psbtGlobal.FALLBACK_LOCKTIME)?.readUInt32LE(
+      0
+    );
+  }
+  setGlobalInputCount(inputCount: number) {
+    this.setGlobal(psbtGlobal.INPUT_COUNT, varint(inputCount));
+  }
+  getGlobalInputCount(): number {
+    return fromVarint(this.getGlobal(psbtGlobal.INPUT_COUNT));
+  }
+  setGlobalOutputCount(outputCount: number) {
+    this.setGlobal(psbtGlobal.OUTPUT_COUNT, varint(outputCount));
+  }
+  getGlobalOutputCount(): number {
+    return fromVarint(this.getGlobal(psbtGlobal.OUTPUT_COUNT));
+  }
+  setGlobalTxModifiable(byte: Buffer) {
+    this.setGlobal(psbtGlobal.TX_MODIFIABLE, byte);
+  }
+  getGlobalTxModifiable(): Buffer | undefined {
+    return this.getGlobalOptional(psbtGlobal.TX_MODIFIABLE);
+  }
+  setGlobalPsbtVersion(psbtVersion: number) {
+    this.setGlobal(psbtGlobal.VERSION, uint32LE(psbtVersion));
+  }
+  getGlobalPsbtVersion(): number {
+    return this.getGlobal(psbtGlobal.VERSION).readUInt32LE(0);
+  }
+
+  setInputNonWitnessUtxo(inputIndex: number, transaction: Buffer) {
+    this.setInput(inputIndex, psbtIn.NON_WITNESS_UTXO, b(), transaction);
+  }
+  getInputNonWitnessUtxo(inputIndex: number): Buffer | undefined {
+    return this.getInputOptional(inputIndex, psbtIn.NON_WITNESS_UTXO, b());
+  }
+  setInputWitnessUtxo(
+    inputIndex: number,
+    amount: Buffer,
+    scriptPubKey: Buffer
+  ) {
+    const buf = new BufferWriter();
+    buf.writeSlice(amount);
+    buf.writeVarSlice(scriptPubKey);
+    this.setInput(inputIndex, psbtIn.WITNESS_UTXO, b(), buf.buffer());
+  }
+  getInputWitnessUtxo(
+    inputIndex: number
+  ): { readonly amount: Buffer; readonly scriptPubKey: Buffer } | undefined {
+    const utxo = this.getInputOptional(inputIndex, psbtIn.WITNESS_UTXO, b());
+    if (!utxo) return undefined;
+    const buf = new BufferReader(utxo);
+    return { amount: buf.readSlice(8), scriptPubKey: buf.readVarSlice() };
+  }
+  setInputPartialSig(inputIndex: number, pubkey: Buffer, signature: Buffer) {
+    this.setInput(inputIndex, psbtIn.PARTIAL_SIG, pubkey, signature);
+  }
+  getInputPartialSig(inputIndex: number, pubkey: Buffer): Buffer | undefined {
+    return this.getInputOptional(inputIndex, psbtIn.PARTIAL_SIG, pubkey);
+  }
+  setInputSighashType(inputIndex: number, sigHashtype: number) {
+    this.setInput(inputIndex, psbtIn.SIGHASH_TYPE, b(), uint32LE(sigHashtype));
+  }
+  getInputSighashType(inputIndex: number): number | undefined {
+    const result = this.getInputOptional(inputIndex, psbtIn.SIGHASH_TYPE, b());
+    if (!result) return undefined;
+    return result.readUInt32LE(0);
+  }
+  setInputRedeemScript(inputIndex: number, redeemScript: Buffer) {
+    this.setInput(inputIndex, psbtIn.REDEEM_SCRIPT, b(), redeemScript);
+  }
+  getInputRedeemScript(inputIndex: number): Buffer | undefined {
+    return this.getInputOptional(inputIndex, psbtIn.REDEEM_SCRIPT, b());
+  }
+  setInputBip32Derivation(
+    inputIndex: number,
+    pubkey: Buffer,
+    masterFingerprint: Buffer,
+    path: readonly number[]
+  ) {
+    if (pubkey.length != 33)
+      throw new Error('Invalid pubkey length: ' + pubkey.length);
+    this.setInput(
+      inputIndex,
+      psbtIn.BIP32_DERIVATION,
+      pubkey,
+      this.encodeBip32Derivation(masterFingerprint, path)
+    );
+  }
+  getInputBip32Derivation(
+    inputIndex: number,
+    pubkey: Buffer
+  ):
+    | { readonly masterFingerprint: Buffer; readonly path: readonly number[] }
+    | undefined {
+    const buf = this.getInputOptional(
+      inputIndex,
+      psbtIn.BIP32_DERIVATION,
+      pubkey
+    );
+    if (!buf) return undefined;
+    return this.decodeBip32Derivation(buf);
+  }
+  setInputFinalScriptsig(inputIndex: number, scriptSig: Buffer) {
+    this.setInput(inputIndex, psbtIn.FINAL_SCRIPTSIG, b(), scriptSig);
+  }
+  getInputFinalScriptsig(inputIndex: number): Buffer | undefined {
+    return this.getInputOptional(inputIndex, psbtIn.FINAL_SCRIPTSIG, b());
+  }
+  setInputFinalScriptwitness(inputIndex: number, scriptWitness: Buffer) {
+    this.setInput(inputIndex, psbtIn.FINAL_SCRIPTWITNESS, b(), scriptWitness);
+  }
+  getInputFinalScriptwitness(inputIndex: number): Buffer {
+    return this.getInput(inputIndex, psbtIn.FINAL_SCRIPTWITNESS, b());
+  }
+  setInputPreviousTxId(inputIndex: number, txid: Buffer) {
+    this.setInput(inputIndex, psbtIn.PREVIOUS_TXID, b(), txid);
+  }
+  getInputPreviousTxid(inputIndex: number): Buffer {
+    return this.getInput(inputIndex, psbtIn.PREVIOUS_TXID, b());
+  }
+  setInputOutputIndex(inputIndex: number, outputIndex: number) {
+    this.setInput(inputIndex, psbtIn.OUTPUT_INDEX, b(), uint32LE(outputIndex));
+  }
+  getInputOutputIndex(inputIndex: number): number {
+    return this.getInput(inputIndex, psbtIn.OUTPUT_INDEX, b()).readUInt32LE(0);
+  }
+  setInputSequence(inputIndex: number, sequence: number) {
+    this.setInput(inputIndex, psbtIn.SEQUENCE, b(), uint32LE(sequence));
+  }
+  getInputSequence(inputIndex: number): number {
+    return (
+      this.getInputOptional(inputIndex, psbtIn.SEQUENCE, b())?.readUInt32LE(
+        0
+      ) ?? 0xffffffff
+    );
+  }
+  setInputTapKeySig(inputIndex: number, sig: Buffer) {
+    this.setInput(inputIndex, psbtIn.TAP_KEY_SIG, b(), sig);
+  }
+  getInputTapKeySig(inputIndex: number): Buffer | undefined {
+    return this.getInputOptional(inputIndex, psbtIn.TAP_KEY_SIG, b());
+  }
+  setInputTapBip32Derivation(
+    inputIndex: number,
+    pubkey: Buffer,
+    hashes: readonly Buffer[],
+    masterFingerprint: Buffer,
+    path: readonly number[]
+  ) {
+    if (pubkey.length != 32)
+      throw new Error('Invalid pubkey length: ' + pubkey.length);
+    const buf = this.encodeTapBip32Derivation(hashes, masterFingerprint, path);
+    this.setInput(inputIndex, psbtIn.TAP_BIP32_DERIVATION, pubkey, buf);
+  }
+  getInputTapBip32Derivation(
+    inputIndex: number,
+    pubkey: Buffer
+  ): {
+    readonly hashes: readonly Buffer[];
+    readonly masterFingerprint: Buffer;
+    readonly path: readonly number[];
+  } {
+    const buf = this.getInput(inputIndex, psbtIn.TAP_BIP32_DERIVATION, pubkey);
+    return this.decodeTapBip32Derivation(buf);
+  }
+  getInputKeyDatas(inputIndex: number, keyType: KeyType): readonly Buffer[] {
+    return this.getKeyDatas(this.inputMaps[inputIndex], keyType);
+  }
+
+  setOutputRedeemScript(outputIndex: number, redeemScript: Buffer) {
+    this.setOutput(outputIndex, psbtOut.REDEEM_SCRIPT, b(), redeemScript);
+  }
+  getOutputRedeemScript(outputIndex: number): Buffer {
+    return this.getOutput(outputIndex, psbtOut.REDEEM_SCRIPT, b());
+  }
+  setOutputBip32Derivation(
+    outputIndex: number,
+    pubkey: Buffer,
+    masterFingerprint: Buffer,
+    path: readonly number[]
+  ) {
+    this.setOutput(
+      outputIndex,
+      psbtOut.BIP_32_DERIVATION,
+      pubkey,
+      this.encodeBip32Derivation(masterFingerprint, path)
+    );
+  }
+  getOutputBip32Derivation(
+    outputIndex: number,
+    pubkey: Buffer
+  ): { readonly masterFingerprint: Buffer; readonly path: readonly number[] } {
+    const buf = this.getOutput(outputIndex, psbtOut.BIP_32_DERIVATION, pubkey);
+    return this.decodeBip32Derivation(buf);
+  }
+  setOutputAmount(outputIndex: number, amount: number) {
+    this.setOutput(outputIndex, psbtOut.AMOUNT, b(), uint64LE(amount));
+  }
+  getOutputAmount(outputIndex: number): number {
+    const buf = this.getOutput(outputIndex, psbtOut.AMOUNT, b());
+    return unsafeFrom64bitLE(buf);
+  }
+  setOutputScript(outputIndex: number, scriptPubKey: Buffer) {
+    this.setOutput(outputIndex, psbtOut.SCRIPT, b(), scriptPubKey);
+  }
+  getOutputScript(outputIndex: number): Buffer {
+    return this.getOutput(outputIndex, psbtOut.SCRIPT, b());
+  }
+  setOutputTapBip32Derivation(
+    outputIndex: number,
+    pubkey: Buffer,
+    hashes: readonly Buffer[],
+    fingerprint: Buffer,
+    path: readonly number[]
+  ) {
+    const buf = this.encodeTapBip32Derivation(hashes, fingerprint, path);
+    this.setOutput(outputIndex, psbtOut.TAP_BIP32_DERIVATION, pubkey, buf);
+  }
+  getOutputTapBip32Derivation(
+    outputIndex: number,
+    pubkey: Buffer
+  ): {
+    readonly hashes: readonly Buffer[];
+    readonly masterFingerprint: Buffer;
+    readonly path: readonly number[];
+  } {
+    const buf = this.getOutput(
+      outputIndex,
+      psbtOut.TAP_BIP32_DERIVATION,
+      pubkey
+    );
+    return this.decodeTapBip32Derivation(buf);
+  }
+
+  deleteInputEntries(inputIndex: number, keyTypes: readonly psbtIn[]) {
+    const map = this.inputMaps[inputIndex];
+    map.forEach((_v, k, m) => {
+      if (this.isKeyType(k, keyTypes)) {
+        m.delete(k);
+      }
+    });
+  }
+
+  copy(to: PsbtV2) {
+    this.copyMap(this.globalMap, to.globalMap);
+    this.copyMaps(this.inputMaps, to.inputMaps);
+    this.copyMaps(this.outputMaps, to.outputMaps);
+  }
+  copyMaps(
+    from: readonly ReadonlyMap<string, Buffer>[],
+    to: Map<string, Buffer>[]
+  ) {
+    from.forEach((m, index) => {
+      const to_index = new Map();
+      this.copyMap(m, to_index);
+      to[index] = to_index;
+    });
+  }
+  copyMap(from: ReadonlyMap<string, Buffer>, to: Map<string, Buffer>) {
+    from.forEach((v, k) => to.set(k, Buffer.from(v)));
+  }
+  serialize(): Buffer {
+    const buf = new BufferWriter();
+    buf.writeSlice(Buffer.from([0x70, 0x73, 0x62, 0x74, 0xff]));
+    serializeMap(buf, this.globalMap);
+    this.inputMaps.forEach((map) => {
+      serializeMap(buf, map);
+    });
+    this.outputMaps.forEach((map) => {
+      serializeMap(buf, map);
+    });
+    return buf.buffer();
+  }
+  deserialize(psbt: Buffer) {
+    const buf = new BufferReader(psbt);
+    if (!buf.readSlice(5).equals(PSBT_MAGIC_BYTES)) {
+      throw new Error('Invalid magic bytes');
+    }
+    while (this.readKeyPair(this.globalMap, buf));
+    for (let i = 0; i < this.getGlobalInputCount(); i++) {
+      this.inputMaps[i] = new Map();
+      while (this.readKeyPair(this.inputMaps[i], buf));
+    }
+    for (let i = 0; i < this.getGlobalOutputCount(); i++) {
+      this.outputMaps[i] = new Map();
+      while (this.readKeyPair(this.outputMaps[i], buf));
+    }
+  }
+  private readKeyPair(map: Map<string, Buffer>, buf: BufferReader): boolean {
+    const keyLen = sanitizeVarintToNumber(buf.readVarInt());
+    if (keyLen == 0) {
+      return false;
+    }
+    const keyType = buf.readUInt8();
+    const keyData = buf.readSlice(keyLen - 1);
+    const value = buf.readVarSlice();
+    set(map, keyType, keyData, value);
+    return true;
+  }
+  private getKeyDatas(
+    map: ReadonlyMap<string, Buffer>,
+    keyType: KeyType
+  ): readonly Buffer[] {
+    const result: Buffer[] = [];
+    map.forEach((_v, k) => {
+      if (this.isKeyType(k, [keyType])) {
+        result.push(Buffer.from(k.substring(2), 'hex'));
+      }
+    });
+    return result;
+  }
+  private isKeyType(hexKey: string, keyTypes: readonly KeyType[]): boolean {
+    const keyType = Buffer.from(hexKey.substring(0, 2), 'hex').readUInt8(0);
+    return keyTypes.some((k) => k == keyType);
+  }
+  private setGlobal(keyType: KeyType, value: Buffer) {
+    const key = new Key(keyType, Buffer.from([]));
+    this.globalMap.set(key.toString(), value);
+  }
+  private getGlobal(keyType: KeyType): Buffer {
+    return get(this.globalMap, keyType, b(), false)!;
+  }
+  private getGlobalOptional(keyType: KeyType): Buffer | undefined {
+    return get(this.globalMap, keyType, b(), true);
+  }
+  private setInput(
+    index: number,
+    keyType: KeyType,
+    keyData: Buffer,
+    value: Buffer
+  ) {
+    set(this.getMap(index, this.inputMaps), keyType, keyData, value);
+  }
+  private getInput(index: number, keyType: KeyType, keyData: Buffer): Buffer {
+    return get(this.inputMaps[index], keyType, keyData, false)!;
+  }
+  private getInputOptional(
+    index: number,
+    keyType: KeyType,
+    keyData: Buffer
+  ): Buffer | undefined {
+    return get(this.inputMaps[index], keyType, keyData, true);
+  }
+  private setOutput(
+    index: number,
+    keyType: KeyType,
+    keyData: Buffer,
+    value: Buffer
+  ) {
+    set(this.getMap(index, this.outputMaps), keyType, keyData, value);
+  }
+  private getOutput(index: number, keyType: KeyType, keyData: Buffer): Buffer {
+    return get(this.outputMaps[index], keyType, keyData, false)!;
+  }
+  private getMap(
+    index: number,
+    maps: Map<string, Buffer>[]
+  ): Map<string, Buffer> {
+    if (maps[index]) {
+      return maps[index];
+    }
+    return (maps[index] = new Map());
+  }
+  private encodeBip32Derivation(
+    masterFingerprint: Buffer,
+    path: readonly number[]
+  ) {
+    const buf = new BufferWriter();
+    this.writeBip32Derivation(buf, masterFingerprint, path);
+    return buf.buffer();
+  }
+  private decodeBip32Derivation(buffer: Buffer): {
+    readonly masterFingerprint: Buffer;
+    readonly path: readonly number[];
+  } {
+    const buf = new BufferReader(buffer);
+    return this.readBip32Derivation(buf);
+  }
+  private writeBip32Derivation(
+    buf: BufferWriter,
+    masterFingerprint: Buffer,
+    path: readonly number[]
+  ) {
+    buf.writeSlice(masterFingerprint);
+    path.forEach((element) => {
+      buf.writeUInt32(element);
+    });
+  }
+  private readBip32Derivation(buf: BufferReader): {
+    readonly masterFingerprint: Buffer;
+    readonly path: readonly number[];
+  } {
+    const masterFingerprint = buf.readSlice(4);
+    const path: number[] = [];
+    while (buf.offset < buf.buffer.length) {
+      path.push(buf.readUInt32());
+    }
+    return { masterFingerprint, path };
+  }
+  private encodeTapBip32Derivation(
+    hashes: readonly Buffer[],
+    masterFingerprint: Buffer,
+    path: readonly number[]
+  ): Buffer {
+    const buf = new BufferWriter();
+    buf.writeVarInt(hashes.length);
+    hashes.forEach((h) => {
+      buf.writeSlice(h);
+    });
+    this.writeBip32Derivation(buf, masterFingerprint, path);
+    return buf.buffer();
+  }
+  private decodeTapBip32Derivation(buffer: Buffer): {
+    readonly hashes: readonly Buffer[];
+    readonly masterFingerprint: Buffer;
+    readonly path: readonly number[];
+  } {
+    const buf = new BufferReader(buffer);
+    const hashCount = sanitizeVarintToNumber(buf.readVarInt());
+    const hashes: Buffer[] = [];
+    for (let i = 0; i < hashCount; i++) {
+      hashes.push(buf.readSlice(32));
+    }
+    const deriv = this.readBip32Derivation(buf);
+    return { hashes, ...deriv };
+  }
+}
+function get(
+  map: ReadonlyMap<string, Buffer>,
+  keyType: KeyType,
+  keyData: Buffer,
+  acceptUndefined: boolean
+): Buffer | undefined {
+  if (!map) throw Error('No such map');
+  const key = new Key(keyType, keyData);
+  const value = map.get(key.toString());
+  if (!value) {
+    if (acceptUndefined) {
+      return undefined;
+    }
+    throw new NoSuchEntry(key.toString());
+  }
+  // Make sure to return a copy, to protect the underlying data.
+  return Buffer.from(value);
+}
+type KeyType = number;
+
+class Key {
+  readonly keyType: KeyType;
+  readonly keyData: Buffer;
+  constructor(keyType: KeyType, keyData: Buffer) {
+    this.keyType = keyType;
+    this.keyData = keyData;
+  }
+  toString(): string {
+    const buf = new BufferWriter();
+    this.toBuffer(buf);
+    return buf.buffer().toString('hex');
+  }
+  serialize(buf: BufferWriter) {
+    buf.writeVarInt(1 + this.keyData.length);
+    this.toBuffer(buf);
+  }
+  private toBuffer(buf: BufferWriter) {
+    buf.writeUInt8(this.keyType);
+    buf.writeSlice(this.keyData);
+  }
+}
+class KeyPair {
+  readonly key: Key;
+  readonly value: Buffer;
+  constructor(key: Key, value: Buffer) {
+    this.key = key;
+    this.value = value;
+  }
+  serialize(buf: BufferWriter) {
+    this.key.serialize(buf);
+    buf.writeVarSlice(this.value);
+  }
+}
+function createKey(buf: Buffer): Key {
+  return new Key(buf.readUInt8(0), buf.slice(1));
+}
+function serializeMap(buf: BufferWriter, map: ReadonlyMap<string, Buffer>) {
+  for (const k in map.keys) {
+    const value = map.get(k)!;
+    const keyPair = new KeyPair(createKey(Buffer.from(k, 'hex')), value);
+    keyPair.serialize(buf);
+  }
+  buf.writeUInt8(0);
+}
+
+function b(): Buffer {
+  return Buffer.from([]);
+}
+function set(
+  map: Map<string, Buffer>,
+  keyType: KeyType,
+  keyData: Buffer,
+  value: Buffer
+) {
+  const key = new Key(keyType, keyData);
+  map.set(key.toString(), value);
+}
+function uint32LE(n: number): Buffer {
+  const buf = Buffer.alloc(4);
+  buf.writeUInt32LE(n, 0);
+  return buf;
+}
+function uint64LE(n: number): Buffer {
+  return unsafeTo64bitLE(n);
+}
+function varint(n: number): Buffer {
+  const buf = new BufferWriter();
+  buf.writeVarInt(n);
+  return buf.buffer();
+}
+function fromVarint(buf: Buffer): number {
+  return sanitizeVarintToNumber(new BufferReader(buf).readVarInt());
+}

--- a/bitcoin_client_js/src/lib/varint.ts
+++ b/bitcoin_client_js/src/lib/varint.ts
@@ -1,0 +1,98 @@
+function bigintToSmallEndian(
+  value: bigint,
+  length: number,
+  buffer: Buffer,
+  offset: number
+): void {
+  for (let i = 0; i < length; i++) {
+    if (buffer[i + offset] == undefined) {
+      throw Error('Buffer too small');
+    }
+    buffer[i + offset] = Number(value % BigInt(256));
+    value = value >> BigInt(8);
+  }
+}
+
+function smallEndianToBigint(
+  buffer: Buffer,
+  offset: number,
+  length: number
+): bigint {
+  let result = BigInt(0);
+  for (let i = 0; i < length; i++) {
+    if (buffer[i + offset] == undefined) {
+      throw Error('Buffer too small');
+    }
+    result += BigInt(buffer[i + offset]) << BigInt(i * 8);
+  }
+  return result;
+}
+
+function getVarintSize(value: number | bigint): 1 | 3 | 5 | 9 {
+  if (typeof value == 'number') {
+    if (value > Number.MAX_SAFE_INTEGER) {
+      throw new Error(
+        "createVarint with a 'number' input only support inputs not bigger than MAX_SAFE_INTEGER"
+      );
+    }
+    value = BigInt(value);
+  }
+
+  if (value < BigInt(0)) {
+    throw new Error('Negative numbers are not supported');
+  }
+
+  if (value >= BigInt(1) << BigInt(64)) {
+    throw new Error('Too large for a Bitcoin-style varint');
+  }
+
+  if (value < BigInt(0xfd)) return 1;
+  else if (value <= BigInt(0xffff)) return 3;
+  else if (value <= BigInt(0xffffffff)) return 5;
+  else return 9;
+}
+
+export function parseVarint(
+  data: Buffer,
+  offset: number
+): readonly [bigint, number] {
+  if (data[offset] == undefined) {
+    throw Error('Buffer too small');
+  }
+
+  if (data[offset] < 0xfd) {
+    return [BigInt(data[offset]), 1];
+  } else {
+    let size: number;
+    if (data[offset] === 0xfd) size = 2;
+    else if (data[offset] === 0xfe) size = 4;
+    else size = 8;
+
+    return [smallEndianToBigint(data, offset + 1, size), size + 1];
+  }
+}
+
+export function createVarint(value: number | bigint): Buffer {
+  const size = getVarintSize(value);
+
+  value = BigInt(value);
+
+  const buffer = Buffer.alloc(size);
+  if (size == 1) {
+    buffer[0] = Number(value);
+  } else {
+    if (size == 3) buffer[0] = 0xfd;
+    else if (size === 5) buffer[0] = 0xfe;
+    else buffer[0] = 0xff;
+
+    bigintToSmallEndian(value, size - 1, buffer, 1);
+  }
+  return buffer;
+}
+
+export function sanitizeVarintToNumber(n: bigint): number {
+  if (n < 0) throw Error('Negative bigint is not a valid varint');
+  if (n > Number.MAX_SAFE_INTEGER) throw Error('Too large for a Number');
+
+  return Number(n);
+}

--- a/bitcoin_client_js/tsconfig.json
+++ b/bitcoin_client_js/tsconfig.json
@@ -1,0 +1,54 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "target": "es2017",
+    "outDir": "build/main",
+    "rootDir": "src",
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "declaration": true,
+    "inlineSourceMap": true,
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "resolveJsonModule": true /* Include modules imported with .json extension. */,
+    // "strict": true /* Enable all strict type-checking options. */,
+    /* Strict Type-Checking Options */
+    // "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    // "strictNullChecks": true /* Enable strict null checks. */,
+    // "strictFunctionTypes": true /* Enable strict checking of function types. */,
+    // "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
+    // "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+    // "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+    /* Debugging Options */
+    "traceResolution": false /* Report module resolution log messages. */,
+    "listEmittedFiles": false /* Print names of generated files part of the compilation. */,
+    "listFiles": false /* Print names of files part of the compilation. */,
+    "pretty": true /* Stylize errors and messages using color and context. */,
+    /* Experimental Options */
+    // "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
+    // "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
+    "lib": [
+      "es2017"
+    ],
+    "types": [
+      "jest",
+      "node"
+    ],
+    "typeRoots": [
+      "node_modules/@types",
+      "src/types"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/__tests__/*"
+  ],
+  "compileOnSave": false
+}


### PR DESCRIPTION
This PR adds a standalone JS library as an npm package named "ledger-bitcoin". This library _only_ supports versions 2.0.0 and above of the app.

A big fraction of the code is extracted from @kallerosenbaum's and some of my own previous work on [@ledgerHW/hw-app-btc](https://github.com/LedgerHQ/ledgerjs/tree/master/packages/hw-app-btc/src), but there are some changes in the interface to keep it uniform with the corresponding Python client. Some additional code that was not part of the implementation in @ledgerHW/hw-app-btc is added to complete the client.
Code that is unrelated to the app's protocol was not ported from `hw-app-btc`; that includes psbt finalizer and extractor. Ideally, the entire PSBTv0 and PSBTv2 support should be delegated to an external library that both `ledger-bitcoin` and `ledgerjs` could use − but no such library exists at this time.