### PR TITLE
Avoid unwanted global space usage on non-NanoS

### DIFF
--- a/src/common/base58.c
+++ b/src/common/base58.c
@@ -55,12 +55,15 @@ char const BASE58_ALPHABET[] = {
 };
 
 int base58_decode(const char *in, size_t in_len, uint8_t *out, size_t out_len) {
-    // uint8_t tmp[MAX_DEC_INPUT_SIZE] = {0};
-    // uint8_t buffer[MAX_DEC_INPUT_SIZE] = {0};
-
+#ifdef USE_CXRAM_SECTION
     // allocate buffers inside the cxram section; safe as there are no syscalls here
     uint8_t *tmp = get_cxram_buffer();                          // MAX_DEC_INPUT_SIZE bytes buffer
     uint8_t *buffer = get_cxram_buffer() + MAX_DEC_INPUT_SIZE;  // MAX_DEC_INPUT_SIZE bytes buffer
+#else
+    uint8_t tmp[MAX_DEC_INPUT_SIZE] = {0};
+    uint8_t buffer[MAX_DEC_INPUT_SIZE] = {0};
+#endif
+
     memset(tmp, 0, MAX_DEC_INPUT_SIZE);
     memset(buffer, 0, MAX_DEC_INPUT_SIZE);
 

--- a/src/cxram_stash.c
+++ b/src/cxram_stash.c
@@ -9,15 +9,7 @@
 union cx_u G_cx;
 #endif
 
-#ifndef USE_CXRAM_SECTION
-
-uint8_t G_cxram_replacement_buffer[1024];
-
-uint8_t *get_cxram_buffer() {
-    return G_cxram_replacement_buffer;
-}
-
-#else
+#ifdef USE_CXRAM_SECTION
 
 uint8_t *get_cxram_buffer() {
     return (uint8_t *) &G_cx;

--- a/src/cxram_stash.h
+++ b/src/cxram_stash.h
@@ -4,11 +4,14 @@
  * Due to lack of available stack on NanoS, we make use of a 1K RAM region that is shared between
  * applications and bolos, and used as temporary memory for cryptographic computations.
  *
- * If USE_CXRAM_SECTION is not set, we define a 1K global buffer, and use that instead.
+ * If USE_CXRAM_SECTION is not set, we don't define this functions; a local buffer in stack must be
+ * used instead.
  */
 
 /**
- * Returns the address of the 1K cxram section, or the global 1K replacement stash
- * if USE_CXRAM_SECTION is not set.
+ * Returns the address of the 1K cxram section.
  */
+
+#ifdef USE_CXRAM_SECTION
 uint8_t *get_cxram_buffer();
+#endif

--- a/unit-tests/test_base58.c
+++ b/unit-tests/test_base58.c
@@ -7,12 +7,6 @@
 
 #include <cmocka.h>
 
-uint8_t G_cxram_replacement_buffer[1024];
-
-uint8_t *get_cxram_buffer() {
-    return G_cxram_replacement_buffer;
-}
-
 #include "common/base58.h"
 
 static void test_base58(void **state) {


### PR DESCRIPTION
Using the global space as a replacement for cxram (optimization to save stack on NanoS) was unsafe and caused memory corruption that broke the exchange app in some situations.
This avoids defining the `get_cxram_buffer` when `USE_CXRAM_SECTION` is not defined, avoiding the risk of using the global space without realizing (app won't compile if `get_cxram_buffer` is used, explicitly labeling code that is using it).