### PR TITLE
Update JS client libraries; update python lib and app code to wallet policies naming

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -184,6 +184,33 @@ jobs:
           pip install -r requirements.txt
           PYTHONPATH=$PYTHONPATH:/speculos pytest --headless --model=${{ matrix.model }} --sdk=${{ matrix.SDK }}
 
+  job_test_python_lib_legacyapp:
+    name: Tests with the Python library and legacy Bitcoin app
+    needs: job_build
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin-custom:latest
+      ports:
+        - 1234:1234
+        - 9999:9999
+        - 40000:40000
+        - 41000:41000
+        - 42000:42000
+        - 43000:43000
+      options: --entrypoint /bin/bash
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          cd bitcoin_client/tests
+          pip install -r requirements.txt
+          PYTHONPATH=$PYTHONPATH:/speculos pytest --headless
+
+
   job_test_js_lib:
     name: Tests with the JS library
     needs: job_build

--- a/bitcoin_client/CHANGELOG.md
+++ b/bitcoin_client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are in `dd-mm-yyyy` format.
 
+## [0.1.0] - TODO
+
+### Changed
+
+Upgraded library to version 2.1.0 of the app.
+
 ## [0.0.3] - 25-04-2022
 
 ### Changed

--- a/bitcoin_client/README.md
+++ b/bitcoin_client/README.md
@@ -53,7 +53,7 @@ Testing the `sign_psbt` method requires producing a valid PSBT (with any externa
 
 ```python
 from typing import Optional
-from ledger_bitcoin import createClient, Chain, MultisigWallet, MultisigWallet, PolicyMapWallet, AddressType, TransportClient
+from ledger_bitcoin import createClient, Chain, MultisigWallet, MultisigWallet, WalletPolicy, AddressType, TransportClient
 from ledger_bitcoin.psbt import PSBT
 
 
@@ -71,9 +71,9 @@ def main():
         # ==> Get and display on screen the first taproot address
 
         first_taproot_account_pubkey = client.get_extended_pubkey("m/86'/1'/0'")
-        first_taproot_account_policy = PolicyMapWallet(
+        first_taproot_account_policy = WalletPolicy(
             "",
-            "tr(@0)",
+            "tr(@0/**)",
             [
                 f"[{fpr}/86'/1'/0']{first_taproot_account_pubkey}/**"
             ],
@@ -98,8 +98,8 @@ def main():
             address_type=AddressType.WIT,
             threshold=2,
             keys_info=[
-                other_key_info,                          # some other bitcoiner
-                f"[{fpr}/48'/1'/0'/2']{our_pubkey}/**",  # that's us
+                other_key_info,                       # some other bitcoiner
+                f"[{fpr}/48'/1'/0'/2']{our_pubkey}",  # that's us
             ],
         )
 
@@ -118,7 +118,7 @@ def main():
 
         # TODO: set a wallet policy and a valid psbt file in order to test psbt signing
         psbt_filename: Optional[str] = None
-        signing_policy: Optional[PolicyMapWallet] = None
+        signing_policy: Optional[WalletPolicy] = None
         signing_policy_hmac: Optional[bytes] = None
         if not psbt_filename or not signing_policy:
             print("Nothing to sign :(")

--- a/bitcoin_client/README.md
+++ b/bitcoin_client/README.md
@@ -35,7 +35,7 @@ It is possible to run the app and the library with the [speculos](https://github
 ⚠️ Currently, speculos does not correctly emulate the version of the app, always returning a dummy value; in order to use the library, it is necessary to set the `SPECULOS_APPNAME` environment variable before starting speculos, for example with:
 
 ```
-$ export SPECULOS_APPNAME="Bitcoin Test:2.0.0"
+$ export SPECULOS_APPNAME="Bitcoin Test:2.1.0"
 ```
 
 Similarly, to test the library behavior on a legacy version of the app, one can set the version to `1.6.5` (the final version of the 1.X series).

--- a/bitcoin_client/ledger_bitcoin/__init__.py
+++ b/bitcoin_client/ledger_bitcoin/__init__.py
@@ -5,7 +5,7 @@ from .client_base import Client, TransportClient
 from .client import createClient
 from .common import Chain
 
-from .wallet import AddressType, Wallet, MultisigWallet, PolicyMapWallet, WalletType
+from .wallet import AddressType, WalletPolicy, MultisigWallet, WalletType
 
 __all__ = [
     "Client",
@@ -13,8 +13,7 @@ __all__ = [
     "createClient",
     "Chain",
     "AddressType",
-    "Wallet",
+    "WalletPolicy",
     "MultisigWallet",
-    "PolicyMapWallet",
     "WalletType"
 ]

--- a/bitcoin_client/ledger_bitcoin/client_base.py
+++ b/bitcoin_client/ledger_bitcoin/client_base.py
@@ -8,7 +8,7 @@ from .common import Chain
 from .command_builder import DefaultInsType
 from .exception import DeviceException
 
-from .wallet import Wallet
+from .wallet import WalletPolicy
 from .psbt import PSBT
 from ._serialize import deser_string
 
@@ -146,12 +146,12 @@ class Client:
 
         raise NotImplementedError
 
-    def register_wallet(self, wallet: Wallet) -> Tuple[bytes, bytes]:
+    def register_wallet(self, wallet: WalletPolicy) -> Tuple[bytes, bytes]:
         """Registers a wallet policy with the user. After approval returns the wallet id and hmac to be stored on the client.
 
         Parameters
         ----------
-        wallet : Wallet
+        wallet : WalletPolicy
             The Wallet policy to register on the device.
 
         Returns
@@ -165,7 +165,7 @@ class Client:
 
     def get_wallet_address(
         self,
-        wallet: Wallet,
+        wallet: WalletPolicy,
         wallet_hmac: Optional[bytes],
         change: int,
         address_index: int,
@@ -176,7 +176,7 @@ class Client:
 
         Parameters
         ----------
-        wallet : Wallet
+        wallet : WalletPolicy
             The registered wallet policy, or a standard wallet policy.
 
         wallet_hmac: Optional[bytes]
@@ -199,7 +199,7 @@ class Client:
 
         raise NotImplementedError
 
-    def sign_psbt(self, psbt: PSBT, wallet: Wallet, wallet_hmac: Optional[bytes]) -> List[Tuple[int, bytes, bytes]]:
+    def sign_psbt(self, psbt: PSBT, wallet: WalletPolicy, wallet_hmac: Optional[bytes]) -> List[Tuple[int, bytes, bytes]]:
         """Signs a PSBT using a registered wallet (or a standard wallet that does not need registration).
 
         Signature requires explicit approval from the user.
@@ -212,7 +212,7 @@ class Client:
             The non-witness UTXO must be present for both legacy and SegWit inputs, or the hardware wallet will reject
             signing (this will change for Taproot inputs).
 
-        wallet : Wallet
+        wallet : WalletPolicy
             The registered wallet policy, or a standard wallet policy.
 
         wallet_hmac: Optional[bytes]

--- a/bitcoin_client/ledger_bitcoin/command_builder.py
+++ b/bitcoin_client/ledger_bitcoin/command_builder.py
@@ -1,9 +1,9 @@
 import enum
 from typing import List, Tuple, Mapping, Union, Iterator, Optional
 
-from .common import bip32_path_from_string, AddressType, sha256, hash256, write_varint
+from .common import bip32_path_from_string, write_varint
 from .merkle import get_merkleized_map_commitment, MerkleTree, element_hash
-from .wallet import Wallet
+from .wallet import WalletPolicy
 
 # p2 encodes the protocol version implemented
 CURRENT_PROTOCOL_VERSION = 1
@@ -96,7 +96,7 @@ class BitcoinCommandBuilder:
             cdata=cdata,
         )
 
-    def register_wallet(self, wallet: Wallet):
+    def register_wallet(self, wallet: WalletPolicy):
         wallet_bytes = wallet.serialize()
 
         return self.serialize(
@@ -107,7 +107,7 @@ class BitcoinCommandBuilder:
 
     def get_wallet_address(
         self,
-        wallet: Wallet,
+        wallet: WalletPolicy,
         wallet_hmac: Optional[bytes],
         address_index: int,
         change: bool,
@@ -134,7 +134,7 @@ class BitcoinCommandBuilder:
         global_mapping: Mapping[bytes, bytes],
         input_mappings: List[Mapping[bytes, bytes]],
         output_mappings: List[Mapping[bytes, bytes]],
-        wallet: Wallet,
+        wallet: WalletPolicy,
         wallet_hmac: Optional[bytes],
     ):
 

--- a/bitcoin_client/ledger_bitcoin/wallet.py
+++ b/bitcoin_client/ledger_bitcoin/wallet.py
@@ -38,7 +38,7 @@ class PolicyMapWallet(Wallet):
     Represents a wallet stored with a wallet policy.
     For version V2, the wallet is serialized as follows:
        - 1 byte   : wallet version
-       - 1 byte   : length of the wallet name (max 16)
+       - 1 byte   : length of the wallet name (max 64)
        - (var)    : wallet name (ASCII string)
        - (varint) : length of the descriptor template
        - 32-bytes : sha256 hash of the descriptor template

--- a/bitcoin_client/setup.cfg
+++ b/bitcoin_client/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ledger_bitcoin
-version = 0.0.3
+version = 0.1.0
 author = Ledger
 author_email = hello@ledger.fr
 description = Client for Ledger Nano Bitcoin application

--- a/bitcoin_client/tests/test_get_wallet_address_legacyapp.py
+++ b/bitcoin_client/tests/test_get_wallet_address_legacyapp.py
@@ -1,13 +1,13 @@
-from bitcoin_client.ledger_bitcoin import Client, PolicyMapWallet
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy
 
 
 def test_get_wallet_address_singlesig_legacy(client: Client):
     # legacy address (P2PKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="pkh(@0)",
+        descriptor_template="pkh(@0/**)",
         keys_info=[
-            f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**",
+            f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT",
         ],
     )
     assert client.get_wallet_address(wallet, None, 0,  0, False) == "mz5vLWdM1wHVGSmXUkhKVvZbJ2g4epMXSm"
@@ -16,11 +16,11 @@ def test_get_wallet_address_singlesig_legacy(client: Client):
 
 def test_get_wallet_address_singlesig_wit(client: Client):
     # bech32 address (P2WPKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="wpkh(@0)",
+        descriptor_template="wpkh(@0/**)",
         keys_info=[
-            f"[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**",
+            f"[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P",
         ],
     )
     assert client.get_wallet_address(wallet, None, 0,  0, False) == "tb1qzdr7s2sr0dwmkwx033r4nujzk86u0cy6fmzfjk"
@@ -29,11 +29,11 @@ def test_get_wallet_address_singlesig_wit(client: Client):
 
 def test_get_wallet_address_singlesig_sh_wit(client: Client):
     # wrapped segwit addresses (P2SH-P2WPKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="sh(wpkh(@0))",
+        descriptor_template="sh(wpkh(@0/**))",
         keys_info=[
-            f"[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3/**",
+            f"[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3",
         ],
     )
     assert client.get_wallet_address(wallet, None, 0,  0, False) == "2MyHkbusvLomaarGYMqyq7q9pSBYJRwWcsw"

--- a/bitcoin_client/tests/test_sign_psbt_legacyapp.py
+++ b/bitcoin_client/tests/test_sign_psbt_legacyapp.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from bitcoin_client.ledger_bitcoin import Client, PolicyMapWallet
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy
 
 from bitcoin_client.ledger_bitcoin.psbt import PSBT
 
@@ -26,11 +26,11 @@ def test_sign_psbt_singlesig_pkh_1to1(client: Client):
     # PSBT for a legacy 1-input 1-output spend (no change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/pkh-1to1.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
-        "pkh(@0)",
+        "pkh(@0/**)",
         [
-            "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**"
+            "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT"
         ],
     )
 
@@ -54,11 +54,11 @@ def test_sign_psbt_singlesig_sh_wpkh_1to2(client: Client):
     # PSBT for a wrapped segwit 1-input 2-output spend (1 change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/sh-wpkh-1to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
-        "sh(wpkh(@0))",
+        "sh(wpkh(@0/**))",
         [
-            "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3/**"
+            "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3"
         ],
     )
 
@@ -82,11 +82,11 @@ def test_sign_psbt_singlesig_wpkh_1to2(client: Client):
     # PSBT for a legacy 1-input 2-output spend (1 change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
-        "wpkh(@0)",
+        "wpkh(@0/**)",
         [
-            "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**"
+            "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P"
         ],
     )
 
@@ -111,11 +111,11 @@ def test_sign_psbt_singlesig_wpkh_2to2(client: Client):
 
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-2to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
-        "wpkh(@0)",
+        "wpkh(@0/**)",
         [
-            "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**"
+            "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P"
         ],
     )
 

--- a/bitcoin_client_js/README.md
+++ b/bitcoin_client_js/README.md
@@ -99,6 +99,11 @@ async function main(transport) {
     const psbt = new PsbtV2();
     psbt.deserialize(rawPsbtBase64);
 
+    // result will be a list of triples [i, pubkey, signature], where:
+    // - i is the input index
+    // - pubkey is either a 33-byte compressed pubkey, or a 32-byte x-only pubkey
+    // - signature is the signature for the corresponding input/pubkey; the signature is concatenated with
+    //   the 1-byte sighash-type (except if the sighash type is SIGHASH_DEFAULT in taproot signing).
     const result = await app.signPsbt(psbt, signingPolicy, signingPolicyHmac);
 
     console.log("Returned signatures:");

--- a/bitcoin_client_js/README.md
+++ b/bitcoin_client_js/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TypeScript client for Ledger Bitcoin application. Supports versions 2.0.0 and above of the app.
+TypeScript client for Ledger Bitcoin application. Supports versions 2.1.0 and above of the app.
 
 Main repository and documentation: https://github.com/LedgerHQ/app-bitcoin-new
 

--- a/bitcoin_client_js/src/__tests__/appClient.test.ts
+++ b/bitcoin_client_js/src/__tests__/appClient.test.ts
@@ -149,64 +149,64 @@ describe("test AppClient", () => {
     }[] = [
       // legacy
       {
-        policy: new DefaultWalletPolicy("pkh(@0)", "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**"),
+        policy: new DefaultWalletPolicy("pkh(@0/**)", "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT"),
         change: 0,
         addrIndex: 0,
         expResult: "mz5vLWdM1wHVGSmXUkhKVvZbJ2g4epMXSm",
       },
       {
-        policy: new DefaultWalletPolicy("pkh(@0)", "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**"),
+        policy: new DefaultWalletPolicy("pkh(@0/**)", "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT"),
         change: 1,
         addrIndex: 15,
         expResult: "myFCUBRCKFjV7292HnZtiHqMzzHrApobpT",
       },
       // native segwit
       {
-        policy: new DefaultWalletPolicy("wpkh(@0)", "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**"),
+        policy: new DefaultWalletPolicy("wpkh(@0/**)", "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P"),
         change: 0,
         addrIndex: 0,
         expResult: "tb1qzdr7s2sr0dwmkwx033r4nujzk86u0cy6fmzfjk",
       },
       {
-        policy: new DefaultWalletPolicy("wpkh(@0)", "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**"),
+        policy: new DefaultWalletPolicy("wpkh(@0/**)", "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P"),
         change: 1,
         addrIndex: 15,
         expResult: "tb1qlrvzyx8jcjfj2xuy69du9trtxnsvjuped7e289",
       },
       // wrapped segwit
       {
-        policy: new DefaultWalletPolicy("sh(wpkh(@0))", "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3/**"),
+        policy: new DefaultWalletPolicy("sh(wpkh(@0/**))", "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3"),
         change: 0,
         addrIndex: 0,
         expResult: "2MyHkbusvLomaarGYMqyq7q9pSBYJRwWcsw",
       },
       {
-        policy: new DefaultWalletPolicy("sh(wpkh(@0))", "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3/**"),
+        policy: new DefaultWalletPolicy("sh(wpkh(@0/**))", "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3"),
         change: 1,
         addrIndex: 15,
         expResult: "2NAbM4FSeBQG4o85kbXw2YNfKypcnEZS9MR",
       },
       // taproot
       {
-        policy: new DefaultWalletPolicy("tr(@0)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"),
+        policy: new DefaultWalletPolicy("tr(@0/**)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U"),
         change: 0,
         addrIndex: 0,
         expResult: "tb1pws8wvnj99ca6acf8kq7pjk7vyxknah0d9mexckh5s0vu2ccy68js9am6u7",
       },
       {
-        policy: new DefaultWalletPolicy("tr(@0)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"),
+        policy: new DefaultWalletPolicy("tr(@0/**)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U"),
         change: 0,
         addrIndex: 9,
         expResult: "tb1psl7eyk2jyjzq6evqvan854fts7a5j65rth25yqahkd2a765yvj0qggs5ne",
       },
       {
-        policy: new DefaultWalletPolicy("tr(@0)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"),
+        policy: new DefaultWalletPolicy("tr(@0/**)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U"),
         change: 1,
         addrIndex: 0,
         expResult: "tb1pmr60r5vfjmdkrwcu4a2z8h39mzs7a6wf2rfhuml6qgcp940x9cxs7t9pdy",
       },
       {
-        policy: new DefaultWalletPolicy("tr(@0)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"),
+        policy: new DefaultWalletPolicy("tr(@0/**)", "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U"),
         change: 1,
         addrIndex: 9,
         expResult: "tb1p98d6s9jkf0la8ras4nnm72zme5r03fexn29e3pgz4qksdy84ndpqgjak72",
@@ -215,16 +215,16 @@ describe("test AppClient", () => {
       {
         policy: new WalletPolicy(
           "Cold storage",
-          "wsh(sortedmulti(2,@0,@1))",
+          "wsh(sortedmulti(2,@0/**,@1/**))",
           [
-            "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/**",
-            "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK/**",
+            "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+            "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
           ]
         ),
         change: 0,
         addrIndex: 0,
         expResult: "tb1qmyauyzn08cduzdqweexgna2spwd0rndj55fsrkefry2cpuyt4cpsn2pg28",
-        walletHmac: Buffer.from("d6434852fb3caa7edbd1165084968f1691444b3cfc10cf1e431acbbc7f48451f", "hex")
+        walletHmac: Buffer.from("d7c7a60b4ab4a14c1bf8901ba627d72140b2fb907f2b4e35d2e693bce9fbb371", "hex")
       },
     ];
 
@@ -238,10 +238,29 @@ describe("test AppClient", () => {
   it("can register a multisig wallet", async () => {
     const walletPolicy = new WalletPolicy(
       "Cold storage",
-      "wsh(sortedmulti(2,@0,@1))",
+      "wsh(sortedmulti(2,@0/**,@1/**))",
       [
-        "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/**",
-        "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK/**",
+        "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+        "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+      ]
+    );
+
+    const automation = JSON.parse(fs.readFileSync('src/__tests__/automations/register_wallet_accept.json').toString());
+    await setSpeculosAutomation(transport, automation);
+
+    const [walletId, walletHmac] = await app.registerWallet(walletPolicy);
+
+    expect(walletId).toEqual(walletPolicy.getId());
+    expect(walletHmac.length).toEqual(32);
+  });
+
+  it("can register a miniscript wallet", async () => {
+    const walletPolicy = new WalletPolicy(
+      "Decaying 3-of-3",
+      "wsh(thresh(3,pk(@0/**),s:pk(@1/**),s:pk(@2/**),sln:older(12960)))",
+      [
+        "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+        "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
       ]
     );
 
@@ -265,20 +284,33 @@ describe("test AppClient", () => {
     await setSpeculosAutomation(transport, automation);
 
     const walletPolicy = new DefaultWalletPolicy(
-      "wpkh(@0)",
-      "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**"
+      "wpkh(@0/**)",
+      "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P"
     );
 
     const psbt = new PsbtV2();
     psbt.deserialize(psbtBuf);
     const result = await app.signPsbt(psbt, walletPolicy, null, () => {});
 
-    expect(result.size).toEqual(2);
-    expect(result.get(0)).toEqual(Buffer.from(
+    expect(result.length).toEqual(2);
+
+    expect(result[0][0]).toEqual(0);
+    expect(result[0][1]).toEqual(Buffer.from(
+      "03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3",
+      "hex"
+    ));
+    expect(result[0][2]).toEqual(Buffer.from(
       "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01",
       "hex"
     ));
-    expect(result.get(1)).toEqual(Buffer.from(
+
+
+    expect(result[1][0]).toEqual(1);
+    expect(result[1][1]).toEqual(Buffer.from(
+      "0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0",
+      "hex"
+    ));
+    expect(result[1][2]).toEqual(Buffer.from(
       "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001",
       "hex"
     ));

--- a/bitcoin_client_js/src/__tests__/automations/register_wallet_accept.json
+++ b/bitcoin_client_js/src/__tests__/automations/register_wallet_accept.json
@@ -2,7 +2,7 @@
   "version": 1,
   "rules": [
     {
-      "regexp": "Register wallet|Wallet name|Policy map|Key",
+      "regexp": "Register wallet|Wallet name|Wallet policy|Key",
       "actions": [
         ["button", 2, true],
         ["button", 2, false]

--- a/bitcoin_client_js/src/lib/clientCommands.ts
+++ b/bitcoin_client_js/src/lib/clientCommands.ts
@@ -3,6 +3,7 @@ import { crypto } from 'bitcoinjs-lib';
 import { BufferReader } from './buffertools';
 import { hashLeaf, Merkle } from './merkle';
 import { MerkleMap } from './merkleMap';
+import { WalletPolicy } from './policy';
 import { createVarint, sanitizeBigintToNumber } from './varint';
 
 enum ClientCommandCode {
@@ -322,6 +323,14 @@ export class ClientCommandInterpreter {
   addKnownMapping(mm: MerkleMap): void {
     this.addKnownList(mm.keys);
     this.addKnownList(mm.values);
+  }
+
+  addKnownWalletPolicy(wp: WalletPolicy): void {
+    this.addKnownPreimage(wp.serialize());
+    this.addKnownList(
+      wp.keys.map((k) => Buffer.from(k, 'ascii'))
+    );
+    this.addKnownPreimage(Buffer.from(wp.descriptorTemplate));
   }
 
   execute(request: Buffer): Buffer {

--- a/bitcoin_client_js/src/lib/policy.ts
+++ b/bitcoin_client_js/src/lib/policy.ts
@@ -3,6 +3,8 @@ import { crypto } from 'bitcoinjs-lib';
 import { BufferWriter } from './buffertools';
 import { hashLeaf, Merkle } from './merkle';
 
+const WALLET_POLICY_V2 = 2;
+
 /**
  * The Bitcon hardware app uses a descriptors-like thing to describe
  * how to construct output scripts from keys. A "Wallet Policy" consists
@@ -49,20 +51,29 @@ export class WalletPolicy {
     const m = new Merkle(keyBuffers.map((k) => hashLeaf(k)));
 
     const buf = new BufferWriter();
-    buf.writeUInt8(0x01); // wallet type (policy map) // TODO: support version 2 
+    buf.writeUInt8(WALLET_POLICY_V2); // wallet version
+
+    // length of wallet name, and wallet name
     buf.writeVarSlice(Buffer.from(this.name, 'ascii'));
-    buf.writeVarSlice(Buffer.from(this.descriptorTemplate, 'ascii'));
+
+    // length of descriptor template
+    buf.writeVarInt(this.descriptorTemplate.length);
+    // sha256 hash of descriptor template
+    buf.writeSlice(crypto.sha256(Buffer.from(this.descriptorTemplate)));
+
+    // number of keys
     buf.writeVarInt(this.keys.length);
+    // root of Merkle tree of keys
     buf.writeSlice(m.getRoot());
     return buf.buffer();
   }
 }
 
 export type DefaultDescriptorTemplate =
-  | 'pkh(@0)'
-  | 'sh(wpkh(@0))'
-  | 'wpkh(@0)'
-  | 'tr(@0)';
+  | 'pkh(@0/**)'
+  | 'sh(wpkh(@0/**))'
+  | 'wpkh(@0/**)'
+  | 'tr(@0/**)';
 
 /**
  * Simplified class to handle default wallet policies that can be used without policy registration.

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -32,31 +32,31 @@
 #define MAX_POLICY_KEY_INFO_LEN MAX(MAX_POLICY_KEY_INFO_LEN_V1, MAX_POLICY_KEY_INFO_LEN_V2)
 
 // longest supported policy in V1 is "sh(wsh(sortedmulti(5,@0,@1,@2,@3,@4)))", 38 bytes
-#define MAX_WALLET_POLICY_STR_LENGTH_V1 40
+#define MAX_DESCRIPTOR_TEMPLATE_LENGTH_V1 40
 
 #ifdef TARGET_NANOS
 // this amount should be enough for many useful policies
-#define MAX_WALLET_POLICY_STR_LENGTH_V2 192
-#define MAX_WALLET_POLICY_BYTES         264
+#define MAX_DESCRIPTOR_TEMPLATE_LENGTH_V2 192
+#define MAX_WALLET_POLICY_BYTES           264
 #else
 // on larger devices, we can afford to reserve a lot more memory
-#define MAX_WALLET_POLICY_STR_LENGTH_V2 512
-#define MAX_WALLET_POLICY_BYTES         512
+#define MAX_DESCRIPTOR_TEMPLATE_LENGTH_V2 512
+#define MAX_WALLET_POLICY_BYTES           512
 #endif
 
-#define MAX_WALLET_POLICY_STR_LENGTH \
-    MAX(MAX_WALLET_POLICY_STR_LENGTH_V1, MAX_WALLET_POLICY_STR_LENGTH_V2)
+#define MAX_DESCRIPTOR_TEMPLATE_LENGTH \
+    MAX(MAX_DESCRIPTOR_TEMPLATE_LENGTH_V1, MAX_DESCRIPTOR_TEMPLATE_LENGTH_V2)
 
 // at most 92 bytes
 // wallet type (1 byte)
 // name length (1 byte)
 // name (max MAX_WALLET_NAME_LENGTH bytes)
 // policy length (1 byte)
-// policy (max MAX_WALLET_POLICY_STR_LENGTH bytes)
+// policy (max MAX_DESCRIPTOR_TEMPLATE_LENGTH bytes)
 // n_keys (1 byte)
 // keys_merkle_root (32 bytes)
 #define MAX_WALLET_POLICY_SERIALIZED_LENGTH_V1 \
-    (1 + 1 + MAX_WALLET_NAME_LENGTH + 1 + MAX_WALLET_POLICY_STR_LENGTH_V1 + 1 + 32)
+    (1 + 1 + MAX_WALLET_NAME_LENGTH + 1 + MAX_DESCRIPTOR_TEMPLATE_LENGTH_V1 + 1 + 32)
 
 // at most 100 bytes
 // wallet type (1 byte)
@@ -83,12 +83,12 @@ typedef struct {
 typedef struct {
     uint8_t version;  // supported values: WALLET_POLICY_VERSION_V1 and WALLET_POLICY_VERSION_V2
     uint8_t name_len;
-    uint16_t policy_map_len;
+    uint16_t descriptor_template_len;
     char name[MAX_WALLET_NAME_LENGTH + 1];
     union {
         // TODO: rename to "descriptor_template"?
-        char policy_map[MAX_WALLET_POLICY_STR_LENGTH_V1];  // used in V1
-        uint8_t policy_map_sha256[32];                     // used in V2
+        char descriptor_template[MAX_DESCRIPTOR_TEMPLATE_LENGTH_V1];  // used in V1
+        uint8_t descriptor_template_sha256[32];                       // used in V2
     };
     size_t n_keys;
     uint8_t keys_info_merkle_root[32];  // root of the Merkle tree of the keys information
@@ -349,21 +349,20 @@ int parse_policy_map_key_info(buffer_t *buffer, policy_map_key_info_t *out, int 
 #pragma GCC diagnostic pop
 
 /**
- * Parses `in_buf` as a policy map, constructing the abstract syntax tree in the buffer `out` of
+ * Parses `in_buf` as a wallet policy descriptor template, constructing the abstract syntax tree in
+ * the buffer `out` of size `out_len`.
  *
  * When parsing descriptors containing miniscript, this fails if the miniscript is not correct,
  * as defined by the miniscript type system.
  * This does NOT check non-malleability of the miniscript.
- *
- * size `out_len`.
- * @param in_buf the buffer containing the policy map to parse
+ * * @param in_buf the buffer containing the policy map to parse
  * @param out the pointer to the output buffer, which must be 4-byte aligned
  * @param out_len the length of the output buffer
  * @param version either WALLET_POLICY_VERSION_V1 or WALLET_POLICY_VERSION_V2
  * @return 0 on success; -1 in case of parsing error, if the output buffer is unaligned, or if the
  * output buffer is too small.
  */
-int parse_policy_map(buffer_t *in_buf, void *out, size_t out_len, int version);
+int parse_descriptor_template(buffer_t *in_buf, void *out, size_t out_len, int version);
 
 /**
  * Computes additional properties of the given miniscript, to detect malleability and other security

--- a/src/handler/get_wallet_address.c
+++ b/src/handler/get_wallet_address.c
@@ -108,7 +108,7 @@ void handler_get_wallet_address(dispatcher_context_t *dc, uint8_t p2) {
         buffer_t serialized_wallet_policy_buf =
             buffer_create(serialized_wallet_policy, serialized_wallet_policy_len);
 
-        uint8_t policy_map_descriptor[MAX_WALLET_POLICY_STR_LENGTH];
+        uint8_t policy_map_descriptor[MAX_DESCRIPTOR_TEMPLATE_LENGTH];
         if (0 > read_and_parse_wallet_policy(dc,
                                              &serialized_wallet_policy_buf,
                                              &wallet_header,

--- a/src/handler/lib/policy.h
+++ b/src/handler/lib/policy.h
@@ -14,20 +14,21 @@
  * @param buf Pointer to the buffer from which the serialized policy is read from
  * @param wallet_header Pointer to policy_map_wallet_header_t that will receive the policy map
  * header
- * @param policy_map_descriptor Pointer to a buffer of MAX_WALLET_POLICY_STR_LENGTH bytes that will
- * contain the descriptor template as a string
+ * @param policy_map_descriptor_template Pointer to a buffer of MAX_DESCRIPTOR_TEMPLATE_LENGTH bytes
+ * that will contain the descriptor template as a string
  * @param policy_map_bytes Pointer to an array of bytes that will be used for the parsed abstract
  * syntax tree
  * @param policy_map_bytes_len Length of policy_map_bytes in bytes.
  * @return 0 on success, a negative number in case of error.
  */
 // TODO: we should distinguish actual errors from just "policy too big to fit in memory"
-int read_and_parse_wallet_policy(dispatcher_context_t *dispatcher_context,
-                                 buffer_t *buf,
-                                 policy_map_wallet_header_t *wallet_header,
-                                 uint8_t policy_map_descriptor[static MAX_WALLET_POLICY_STR_LENGTH],
-                                 uint8_t *policy_map_bytes,
-                                 size_t policy_map_bytes_len);
+int read_and_parse_wallet_policy(
+    dispatcher_context_t *dispatcher_context,
+    buffer_t *buf,
+    policy_map_wallet_header_t *wallet_header,
+    uint8_t policy_map_descriptor[static MAX_DESCRIPTOR_TEMPLATE_LENGTH],
+    uint8_t *policy_map_bytes,
+    size_t policy_map_bytes_len);
 
 /**
  * Computes the script corresponding to a wallet policy, for a certain change and address index.

--- a/src/handler/register_wallet.c
+++ b/src/handler/register_wallet.c
@@ -77,7 +77,7 @@ void handler_register_wallet(dispatcher_context_t *dc, uint8_t p2) {
         return;
     }
 
-    uint8_t policy_map_descriptor[MAX_WALLET_POLICY_STR_LENGTH];
+    uint8_t policy_map_descriptor[MAX_DESCRIPTOR_TEMPLATE_LENGTH];
     if (0 > read_and_parse_wallet_policy(dc,
                                          &dc->read_buffer,
                                          &wallet_header,

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -632,7 +632,7 @@ init_global_state(dispatcher_context_t *dc, sign_psbt_state_t *st) {
         buffer_t serialized_wallet_policy_buf =
             buffer_create(serialized_wallet_policy, serialized_wallet_policy_len);
 
-        uint8_t policy_map_descriptor[MAX_WALLET_POLICY_STR_LENGTH];
+        uint8_t policy_map_descriptor[MAX_DESCRIPTOR_TEMPLATE_LENGTH];
         if (0 > read_and_parse_wallet_policy(dc,
                                              &serialized_wallet_policy_buf,
                                              &wallet_header,

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -55,7 +55,7 @@ typedef struct {
 
     // no flows show together both a policy map and an address, therefore we share memory
     union {
-        char policy_map[MAX_WALLET_POLICY_STR_LENGTH + 1];
+        char descriptor_template[MAX_DESCRIPTOR_TEMPLATE_LENGTH + 1];
         char address[MAX_ADDRESS_LENGTH_STR + 1];
     };
 } ui_wallet_state_t;
@@ -189,16 +189,16 @@ UX_STEP_NOCB(ux_display_address_step,
                  .text = g_ui_state.path_and_address.address,
              });
 
-// Step with description of a policy wallet
+// Step with description of a wallet policy
 UX_STEP_NOCB(ux_display_wallet_policy_map_step,
              bnnn_paging,
              {
-                 .title = "Policy map:",
-                 .text = g_ui_state.wallet.policy_map,
+                 .title = "Wallet policy:",
+                 .text = g_ui_state.wallet.descriptor_template,
              });
 
 // Step with index and xpub of a cosigner of a policy_map wallet
-UX_STEP_NOCB(ux_display_wallet_policy_map_cosigner_pubkey_step,
+UX_STEP_NOCB(ux_display_wallet_policy_cosigner_pubkey_step,
              bnnn_paging,
              {
                  .title = g_ui_state.cosigner_pubkey_and_index.signer_index,
@@ -432,7 +432,7 @@ UX_FLOW(ux_display_register_wallet_flow,
 // #2 screen: approve button
 // #3 screen: reject button
 UX_FLOW(ux_display_policy_map_cosigner_pubkey_flow,
-        &ux_display_wallet_policy_map_cosigner_pubkey_step,
+        &ux_display_wallet_policy_cosigner_pubkey_step,
         &ux_display_approve_step,
         &ux_display_reject_step);
 
@@ -605,8 +605,8 @@ bool ui_display_register_wallet(dispatcher_context_t *context,
 
     strncpy(state->wallet_name, wallet_header->name, sizeof(state->wallet_name));
     state->wallet_name[wallet_header->name_len] = 0;
-    strncpy(state->policy_map, policy_descriptor, sizeof(state->policy_map));
-    state->policy_map[wallet_header->policy_map_len] = 0;
+    strncpy(state->descriptor_template, policy_descriptor, sizeof(state->descriptor_template));
+    state->descriptor_template[wallet_header->descriptor_template_len] = 0;
 
     ux_flow_init(0, ux_display_register_wallet_flow, NULL);
 

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -4,7 +4,7 @@ from typing import Literal, Union
 from mnemonic import Mnemonic
 from bip32 import BIP32
 
-from bitcoin_client.ledger_bitcoin.wallet import PolicyMapWallet
+from bitcoin_client.ledger_bitcoin.wallet import WalletPolicy
 
 from .slip21 import Slip21Node
 
@@ -83,7 +83,7 @@ def get_internal_xpub(seed: str, path: str) -> str:
     return bip32.get_xpub_from_path(f"m/{path}")
 
 
-def count_internal_keys(seed: str, network: Union[Literal['main'], Literal['test']], wallet_policy: PolicyMapWallet) -> int:
+def count_internal_keys(seed: str, network: Union[Literal['main'], Literal['test']], wallet_policy: WalletPolicy) -> int:
     """Count how many of the keys in wallet_policy are indeed internal"""
 
     bip32 = BIP32.from_seed(seed, network)
@@ -105,6 +105,7 @@ def count_internal_keys(seed: str, network: Union[Literal['main'], Literal['test
                 computed_xpub = get_internal_xpub(seed, path)
                 if computed_xpub == xpub:
                     # there could be multiple placeholders using the same key; we must count all of them
-                    count += wallet_policy.policy_map.count(f"@{key_index}/")
+                    count += wallet_policy.descriptor_template.count(
+                        f"@{key_index}/")
 
     return count

--- a/tests/automations/register_wallet_accept.json
+++ b/tests/automations/register_wallet_accept.json
@@ -2,7 +2,7 @@
   "version": 1,
   "rules": [
     {
-      "regexp": "Register wallet|Wallet name|Policy map|Key",
+      "regexp": "Register wallet|Wallet name|Wallet policy|Key",
       "actions": [
         ["button", 2, true],
         ["button", 2, false]

--- a/tests/automations/register_wallet_reject.json
+++ b/tests/automations/register_wallet_reject.json
@@ -2,7 +2,7 @@
   "version": 1,
   "rules": [
     {
-      "regexp": "Register wallet|Wallet name|Policy map|Key|Approve",
+      "regexp": "Register wallet|Wallet name|Wallet policy|Key|Approve",
       "actions": [
         ["button", 2, true],
         ["button", 2, false]

--- a/tests/test_e2e_multisig.py
+++ b/tests/test_e2e_multisig.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from bitcoin_client.ledger_bitcoin import Client, MultisigWallet, AddressType
 from bitcoin_client.ledger_bitcoin.client_base import TransportClient
 from bitcoin_client.ledger_bitcoin.psbt import PSBT
-from bitcoin_client.ledger_bitcoin.wallet import PolicyMapWallet
+from bitcoin_client.ledger_bitcoin.wallet import WalletPolicy
 
 from test_utils import SpeculosGlobals, get_internal_xpub, count_internal_keys
 
@@ -20,7 +20,7 @@ from .conftest import create_new_wallet, generate_blocks, get_unique_wallet_name
 from .conftest import AuthServiceProxy
 
 
-def run_test(wallet_policy: PolicyMapWallet, core_wallet_names: List[str], rpc: AuthServiceProxy, rpc_test_wallet: AuthServiceProxy, client: Client, speculos_globals: SpeculosGlobals, comm: Union[TransportClient, SpeculosClient]):
+def run_test(wallet_policy: WalletPolicy, core_wallet_names: List[str], rpc: AuthServiceProxy, rpc_test_wallet: AuthServiceProxy, client: Client, speculos_globals: SpeculosGlobals, comm: Union[TransportClient, SpeculosClient]):
     with automation(comm, "automations/register_wallet_accept.json"):
         wallet_id, wallet_hmac = client.register_wallet(wallet_policy)
 

--- a/tests/test_get_wallet_address.py
+++ b/tests/test_get_wallet_address.py
@@ -1,4 +1,4 @@
-from bitcoin_client.ledger_bitcoin import Client, AddressType, MultisigWallet, PolicyMapWallet
+from bitcoin_client.ledger_bitcoin import Client, AddressType, MultisigWallet, WalletPolicy
 from bitcoin_client.ledger_bitcoin.exception.errors import IncorrectDataError
 
 
@@ -9,9 +9,9 @@ import pytest
 
 def test_get_wallet_address_singlesig_legacy(client: Client):
     # legacy address (P2PKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="pkh(@0/**)",
+        descriptor_template="pkh(@0/**)",
         keys_info=[
             f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT",
         ],
@@ -22,9 +22,9 @@ def test_get_wallet_address_singlesig_legacy(client: Client):
 
 def test_get_wallet_address_singlesig_wit(client: Client):
     # bech32 address (P2WPKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="wpkh(@0/**)",
+        descriptor_template="wpkh(@0/**)",
         keys_info=[
             f"[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P",
         ],
@@ -35,9 +35,9 @@ def test_get_wallet_address_singlesig_wit(client: Client):
 
 def test_get_wallet_address_singlesig_sh_wit(client: Client):
     # wrapped segwit addresses (P2SH-P2WPKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="sh(wpkh(@0/**))",
+        descriptor_template="sh(wpkh(@0/**))",
         keys_info=[
             f"[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3",
         ],
@@ -49,9 +49,9 @@ def test_get_wallet_address_singlesig_sh_wit(client: Client):
 def test_get_wallet_address_singlesig_taproot(client: Client):
     # test for a native taproot wallet (bech32m addresses, per BIP-0086)
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="tr(@0/**)",
+        descriptor_template="tr(@0/**)",
         keys_info=[
             f"[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
         ],
@@ -75,17 +75,17 @@ def test_get_wallet_address_singlesig_taproot(client: Client):
 def test_get_wallet_address_default_fail_wrongkeys(client: Client):
     # 0 keys info should be rejected
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0/**)",
+            descriptor_template="pkh(@0/**)",
             keys_info=[],
         ), None, 0,  0, False)
 
     # more than 1 key should be rejected
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0/**)",
+            descriptor_template="pkh(@0/**)",
             keys_info=[
                 f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT",
                 f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT"
@@ -94,9 +94,9 @@ def test_get_wallet_address_default_fail_wrongkeys(client: Client):
 
     # wrong BIP44 purpose should be rejected (here using 84' for a P2PKH address)
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0/**)",
+            descriptor_template="pkh(@0/**)",
             keys_info=[
                 f"[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P",
             ],
@@ -104,9 +104,9 @@ def test_get_wallet_address_default_fail_wrongkeys(client: Client):
 
     # mismatching pubkey (claiming key origin "44'/1'/0'", but that's the extended pubkey for "84'/1'/0'"")
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0/**)",
+            descriptor_template="pkh(@0/**)",
             keys_info=[
                 f"[f5acc2fd/44'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P",
             ],
@@ -114,9 +114,9 @@ def test_get_wallet_address_default_fail_wrongkeys(client: Client):
 
     # wrong master fingerprint
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0/**)",
+            descriptor_template="pkh(@0/**)",
             keys_info=[
                 f"[42424242/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT",
             ],
@@ -124,9 +124,9 @@ def test_get_wallet_address_default_fail_wrongkeys(client: Client):
 
     # too large address_index, cannot be done non-silently
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0/**)",
+            descriptor_template="pkh(@0/**)",
             keys_info=[
                 f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT",
             ],

--- a/tests/test_get_wallet_address_v1.py
+++ b/tests/test_get_wallet_address_v1.py
@@ -1,7 +1,7 @@
 # Tests using the V1 version of the wallet policy language, used before version 2.1.0 of the app
 # Make sure we remain compatible for some time.
 
-from bitcoin_client.ledger_bitcoin import Client, AddressType, MultisigWallet, PolicyMapWallet, WalletType
+from bitcoin_client.ledger_bitcoin import Client, AddressType, MultisigWallet, WalletPolicy, WalletType
 from bitcoin_client.ledger_bitcoin.exception.errors import IncorrectDataError
 
 
@@ -12,9 +12,9 @@ import pytest
 
 def test_get_wallet_address_singlesig_legacy_v1(client: Client):
     # legacy address (P2PKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="pkh(@0)",
+        descriptor_template="pkh(@0)",
         keys_info=[
             f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**",
         ],
@@ -26,9 +26,9 @@ def test_get_wallet_address_singlesig_legacy_v1(client: Client):
 
 def test_get_wallet_address_singlesig_wit_v1(client: Client):
     # bech32 address (P2WPKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="wpkh(@0)",
+        descriptor_template="wpkh(@0)",
         keys_info=[
             f"[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**",
         ],
@@ -40,9 +40,9 @@ def test_get_wallet_address_singlesig_wit_v1(client: Client):
 
 def test_get_wallet_address_singlesig_sh_wit_v1(client: Client):
     # wrapped segwit addresses (P2SH-P2WPKH)
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="sh(wpkh(@0))",
+        descriptor_template="sh(wpkh(@0))",
         keys_info=[
             f"[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3/**",
         ],
@@ -55,9 +55,9 @@ def test_get_wallet_address_singlesig_sh_wit_v1(client: Client):
 def test_get_wallet_address_singlesig_taproot_v1(client: Client):
     # test for a native taproot wallet (bech32m addresses, per BIP-0086)
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="tr(@0)",
+        descriptor_template="tr(@0)",
         keys_info=[
             f"[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**",
         ],
@@ -82,18 +82,18 @@ def test_get_wallet_address_singlesig_taproot_v1(client: Client):
 def test_get_wallet_address_default_fail_wrongkeys_v1(client: Client):
     # 0 keys info should be rejected
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0)",
+            descriptor_template="pkh(@0)",
             keys_info=[],
             version=WalletType.WALLET_POLICY_V1
         ), None, 0,  0, False)
 
     # more than 1 key should be rejected
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0)",
+            descriptor_template="pkh(@0)",
             keys_info=[
                 f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**",
                 f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**"
@@ -102,9 +102,9 @@ def test_get_wallet_address_default_fail_wrongkeys_v1(client: Client):
 
     # wrong BIP44 purpose should be rejected (here using 84' for a P2PKH address)
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0)",
+            descriptor_template="pkh(@0)",
             keys_info=[
                 f"[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**",
             ],
@@ -113,9 +113,9 @@ def test_get_wallet_address_default_fail_wrongkeys_v1(client: Client):
 
     # mismatching pubkey (claiming key origin "44'/1'/0'", but that's the extended dpubkey for "84'/1'/0'"")
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0)",
+            descriptor_template="pkh(@0)",
             keys_info=[
                 f"[f5acc2fd/44'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P/**",
             ],
@@ -123,9 +123,9 @@ def test_get_wallet_address_default_fail_wrongkeys_v1(client: Client):
 
     # wrong master fingerprint
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0)",
+            descriptor_template="pkh(@0)",
             keys_info=[
                 f"[42424242/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**",
             ],
@@ -134,9 +134,9 @@ def test_get_wallet_address_default_fail_wrongkeys_v1(client: Client):
 
     # too large address_index, cannot be done non-silently
     with pytest.raises(IncorrectDataError):
-        client.get_wallet_address(PolicyMapWallet(
+        client.get_wallet_address(WalletPolicy(
             name="",
-            policy_map="pkh(@0)",
+            descriptor_template="pkh(@0)",
             keys_info=[
                 f"[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/**",
             ],

--- a/tests/test_register_wallet_v1.py
+++ b/tests/test_register_wallet_v1.py
@@ -1,7 +1,7 @@
 # Tests using the V1 version of the wallet policy language, used before version 2.1.0 of the app
 # Make sure we remain compatible for some time.
 
-from bitcoin_client.ledger_bitcoin import Client, AddressType, MultisigWallet, PolicyMapWallet, WalletType
+from bitcoin_client.ledger_bitcoin import Client, AddressType, MultisigWallet, WalletPolicy, WalletType
 from bitcoin_client.ledger_bitcoin.exception.errors import IncorrectDataError, NotSupportedError
 from bitcoin_client.ledger_bitcoin.exception import DenyError
 
@@ -127,9 +127,9 @@ def test_register_wallet_unsupported_policy_v1(client: Client):
     # valid policies, but not supported (might change in the future)
 
     with pytest.raises(NotSupportedError):
-        client.register_wallet(PolicyMapWallet(
+        client.register_wallet(WalletPolicy(
             name="Unsupported",
-            policy_map="pk(@0)",  # bare pubkey, not supported
+            descriptor_template="pk(@0)",  # bare pubkey, not supported
             keys_info=[
                 f"[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/**",
             ],

--- a/tests/test_sign_psbt.py
+++ b/tests/test_sign_psbt.py
@@ -8,7 +8,7 @@ from typing import List
 
 from pathlib import Path
 
-from bitcoin_client.ledger_bitcoin import Client, PolicyMapWallet, MultisigWallet, AddressType
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy, MultisigWallet, AddressType
 from bitcoin_client.ledger_bitcoin.exception.errors import IncorrectDataError, NotSupportedError
 
 from bitcoin_client.ledger_bitcoin.psbt import PSBT
@@ -124,7 +124,7 @@ def test_sign_psbt_singlesig_pkh_1to1(client: Client):
     # PSBT for a legacy 1-input 1-output spend (no change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/pkh-1to1.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "pkh(@0/**)",
         [
@@ -153,7 +153,7 @@ def test_sign_psbt_singlesig_sh_wpkh_1to2(client: Client):
     # PSBT for a wrapped segwit 1-input 2-output spend (1 change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/sh-wpkh-1to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "sh(wpkh(@0/**))",
         [
@@ -182,7 +182,7 @@ def test_sign_psbt_singlesig_wpkh_1to2(client: Client):
     # PSBT for a segwit 1-input 2-output spend (1 change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -212,7 +212,7 @@ def test_sign_psbt_singlesig_wpkh_2to2(client: Client):
 
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-2to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -256,7 +256,7 @@ def test_sign_psbt_singlesig_wpkh_2to2_missing_nonwitnessutxo(client: Client):
     for input in psbt.inputs:
         input.non_witness_utxo = None
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -368,7 +368,7 @@ def test_sign_psbt_taproot_1to2_sighash_all(client: Client):
 
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/tr-1to2-sighash-all.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "tr(@0/**)",
         [
@@ -406,7 +406,7 @@ def test_sign_psbt_taproot_1to2_sighash_default(client: Client):
 
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/tr-1to2-sighash-default.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "tr(@0/**)",
         [
@@ -444,7 +444,7 @@ def test_sign_psbt_singlesig_wpkh_4to3(client: Client, comm: SpeculosClient, is_
     if not is_speculos:
         pytest.skip("Requires speculos")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -507,7 +507,7 @@ def test_sign_psbt_singlesig_large_amount(client: Client, comm: SpeculosClient, 
     if not is_speculos:
         pytest.skip("Requires speculos")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -557,7 +557,7 @@ def test_sign_psbt_singlesig_wpkh_512to256(client: Client, enable_slow_tests: bo
     n_inputs = 512
     n_outputs = 256
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "tr(@0/**)",
         [
@@ -581,7 +581,7 @@ def test_sign_psbt_fail_11_changes(client: Client):
     # PSBT for transaction with 11 change addresses; the limit is 10, so it must fail with NotSupportedError
     # before any user interaction
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -607,7 +607,7 @@ def test_sign_psbt_fail_wrong_non_witness_utxo(client: Client, is_speculos: bool
     if not is_speculos:
         pytest.skip("Requires speculos")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -635,7 +635,7 @@ def test_sign_psbt_fail_wrong_non_witness_utxo(client: Client, is_speculos: bool
 
 
 def test_sign_psbt_with_opreturn(client: Client, comm: SpeculosClient):
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -662,7 +662,7 @@ def test_sign_psbt_with_segwit_v16(client: Client, comm: SpeculosClient):
     psbt = PSBT()
     psbt.deserialize(psbt_b64)
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0/**)",
         [
@@ -684,21 +684,21 @@ def test_sign_psbt_with_external_inputs(client: Client, comm: SpeculosClient):
     psbt.deserialize(psbt_b64)
 
     wallets = [
-        PolicyMapWallet(
+        WalletPolicy(
             "",
             "pkh(@0/**)",
             [
                 "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT"
             ],
         ),
-        PolicyMapWallet(
+        WalletPolicy(
             "",
             "tr(@0/**)",
             [
                 "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U"
             ],
         ),
-        PolicyMapWallet(
+        WalletPolicy(
             "",
             "wpkh(@0/**)",
             [
@@ -725,7 +725,7 @@ def test_sign_psbt_miniscript_multikey(client: Client, comm: SpeculosClient):
     psbt = PSBT()
     psbt.deserialize(psbt_b64)
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "Me and Bob or me and Carl",
         "wsh(c:andor(pk(@0/<0;1>/*),pk_k(@1/**),and_v(v:pk(@0/<2;3>/*),pk_k(@2/**))))",
         [

--- a/tests/test_sign_psbt_v1.py
+++ b/tests/test_sign_psbt_v1.py
@@ -11,7 +11,7 @@ from typing import List
 
 from pathlib import Path
 
-from bitcoin_client.ledger_bitcoin import Client, PolicyMapWallet, MultisigWallet, AddressType, WalletType
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy, MultisigWallet, AddressType, WalletType
 from bitcoin_client.ledger_bitcoin.exception.errors import IncorrectDataError, NotSupportedError
 
 from bitcoin_client.ledger_bitcoin.psbt import PSBT
@@ -127,7 +127,7 @@ def test_sign_psbt_singlesig_pkh_1to1_v1(client: Client):
     # PSBT for a legacy 1-input 1-output spend (no change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/pkh-1to1.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "pkh(@0)",
         [
@@ -157,7 +157,7 @@ def test_sign_psbt_singlesig_sh_wpkh_1to2_v1(client: Client):
     # PSBT for a wrapped segwit 1-input 2-output spend (1 change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/sh-wpkh-1to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "sh(wpkh(@0))",
         [
@@ -187,7 +187,7 @@ def test_sign_psbt_singlesig_wpkh_1to2_v1(client: Client):
     # PSBT for a legacy 1-input 2-output spend (1 change address)
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0)",
         [
@@ -218,7 +218,7 @@ def test_sign_psbt_singlesig_wpkh_2to2_v1(client: Client):
 
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-2to2.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0)",
         [
@@ -288,7 +288,7 @@ def test_sign_psbt_taproot_1to2_v1(client: Client):
 
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/tr-1to2-sighash-all.psbt")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "tr(@0)",
         [
@@ -328,7 +328,7 @@ def test_sign_psbt_singlesig_wpkh_4to3_v1(client: Client, comm: SpeculosClient, 
     if not is_speculos:
         pytest.skip("Requires speculos")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0)",
         [
@@ -392,7 +392,7 @@ def test_sign_psbt_singlesig_large_amount_v1(client: Client, comm: SpeculosClien
     if not is_speculos:
         pytest.skip("Requires speculos")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0)",
         [
@@ -443,7 +443,7 @@ def test_sign_psbt_singlesig_wpkh_512to256_v1(client: Client, enable_slow_tests:
     n_inputs = 512
     n_outputs = 256
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "tr(@0)",
         [
@@ -468,7 +468,7 @@ def test_sign_psbt_fail_11_changes_v1(client: Client):
     # PSBT for transaction with 11 change addresses; the limit is 10, so it must fail with NotSupportedError
     # before any user interaction
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0)",
         [
@@ -495,7 +495,7 @@ def test_sign_psbt_fail_wrong_non_witness_utxo_v1(client: Client, is_speculos: b
     if not is_speculos:
         pytest.skip("Requires speculos")
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0)",
         [
@@ -524,7 +524,7 @@ def test_sign_psbt_fail_wrong_non_witness_utxo_v1(client: Client, is_speculos: b
 
 
 def test_sign_psbt_with_opreturn_v1(client: Client, comm: SpeculosClient):
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0)",
         [
@@ -552,7 +552,7 @@ def test_sign_psbt_with_segwit_v16_v1(client: Client, comm: SpeculosClient):
     psbt = PSBT()
     psbt.deserialize(psbt_b64)
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         "",
         "wpkh(@0)",
         [

--- a/tests/test_sign_psbt_with_sighash_types.py
+++ b/tests/test_sign_psbt_with_sighash_types.py
@@ -1,14 +1,14 @@
 import pytest
 import threading
 from pathlib import Path
-from bitcoin_client.ledger_bitcoin import Client, PolicyMapWallet
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy
 from bitcoin_client.ledger_bitcoin.exception.errors import NotSupportedError
 from bitcoin_client.ledger_bitcoin.psbt import PSBT
 from test_utils import has_automation, bip0340
 
 tests_root: Path = Path(__file__).parent
 
-tr_wallet = PolicyMapWallet(
+tr_wallet = WalletPolicy(
     "",
     "tr(@0/**)",
     [
@@ -16,7 +16,7 @@ tr_wallet = PolicyMapWallet(
     ],
 )
 
-wpkh_wallet = PolicyMapWallet(
+wpkh_wallet = WalletPolicy(
     "",
     "wpkh(@0/**)",
     [

--- a/tests_mainnet/test_bip86.py
+++ b/tests_mainnet/test_bip86.py
@@ -1,4 +1,4 @@
-from bitcoin_client.ledger_bitcoin import Client, PolicyMapWallet
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy
 
 from test_utils import SpeculosGlobals, mnemonic
 
@@ -13,9 +13,9 @@ def test_bip86(client: Client, speculos_globals: SpeculosGlobals):
 
     # test for a native taproot wallet (bech32m addresses, per BIP-0086)
 
-    wallet = PolicyMapWallet(
+    wallet = WalletPolicy(
         name="",
-        policy_map="tr(@0/**)",
+        descriptor_template="tr(@0/**)",
         keys_info=[
             f"[{fpr}/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ",
         ],

--- a/unit-tests/test_wallet.c
+++ b/unit-tests/test_wallet.c
@@ -29,10 +29,14 @@ static void test_parse_policy_map_singlesig_1(void **state) {
 
     int res;
 
-    char *policy = "pkh(@0/**)";
-    buffer_t policy_buf = buffer_create((void *) policy, strlen(policy));
+    char *descriptor_template = "pkh(@0/**)";
+    buffer_t descriptor_template_buf =
+        buffer_create((void *) descriptor_template, strlen(descriptor_template));
 
-    res = parse_policy_map(&policy_buf, out, sizeof(out), WALLET_POLICY_VERSION_V2);
+    res = parse_descriptor_template(&descriptor_template_buf,
+                                    out,
+                                    sizeof(out),
+                                    WALLET_POLICY_VERSION_V2);
     assert_int_equal(res, 0);
     policy_node_with_key_t *node_1 = (policy_node_with_key_t *) out;
 
@@ -49,10 +53,14 @@ static void test_parse_policy_map_singlesig_2(void **state) {
 
     int res;
 
-    char *policy = "sh(wpkh(@0/**))";
-    buffer_t policy_buf = buffer_create((void *) policy, strlen(policy));
+    char *descriptor_template = "sh(wpkh(@0/**))";
+    buffer_t descriptor_template_buf =
+        buffer_create((void *) descriptor_template, strlen(descriptor_template));
 
-    res = parse_policy_map(&policy_buf, out, sizeof(out), WALLET_POLICY_VERSION_V2);
+    res = parse_descriptor_template(&descriptor_template_buf,
+                                    out,
+                                    sizeof(out),
+                                    WALLET_POLICY_VERSION_V2);
     assert_int_equal(res, 0);
     policy_node_with_script_t *root = (policy_node_with_script_t *) out;
 
@@ -73,10 +81,14 @@ static void test_parse_policy_map_singlesig_3(void **state) {
 
     int res;
 
-    char *policy = "sh(wsh(pkh(@0/**)))";
-    buffer_t policy_buf = buffer_create((void *) policy, strlen(policy));
+    char *descriptor_template = "sh(wsh(pkh(@0/**)))";
+    buffer_t descriptor_template_buf =
+        buffer_create((void *) descriptor_template, strlen(descriptor_template));
 
-    res = parse_policy_map(&policy_buf, out, sizeof(out), WALLET_POLICY_VERSION_V2);
+    res = parse_descriptor_template(&descriptor_template_buf,
+                                    out,
+                                    sizeof(out),
+                                    WALLET_POLICY_VERSION_V2);
     assert_int_equal(res, 0);
     policy_node_with_script_t *root = (policy_node_with_script_t *) out;
 
@@ -101,10 +113,14 @@ static void test_parse_policy_map_multisig_1(void **state) {
 
     int res;
 
-    char *policy = "sortedmulti(2,@0/**,@1/**,@2/**)";
-    buffer_t policy_buf = buffer_create((void *) policy, strlen(policy));
+    char *descriptor_template = "sortedmulti(2,@0/**,@1/**,@2/**)";
+    buffer_t descriptor_template_buf =
+        buffer_create((void *) descriptor_template, strlen(descriptor_template));
 
-    res = parse_policy_map(&policy_buf, out, sizeof(out), WALLET_POLICY_VERSION_V2);
+    res = parse_descriptor_template(&descriptor_template_buf,
+                                    out,
+                                    sizeof(out),
+                                    WALLET_POLICY_VERSION_V2);
     assert_int_equal(res, 0);
     policy_node_multisig_t *node_1 = (policy_node_multisig_t *) out;
 
@@ -129,10 +145,14 @@ static void test_parse_policy_map_multisig_2(void **state) {
 
     int res;
 
-    char *policy = "wsh(multi(3,@0/**,@1/**,@2/**,@3/**,@4/**))";
-    buffer_t policy_buf = buffer_create((void *) policy, strlen(policy));
+    char *descriptor_template = "wsh(multi(3,@0/**,@1/**,@2/**,@3/**,@4/**))";
+    buffer_t descriptor_template_buf =
+        buffer_create((void *) descriptor_template, strlen(descriptor_template));
 
-    res = parse_policy_map(&policy_buf, out, sizeof(out), WALLET_POLICY_VERSION_V2);
+    res = parse_descriptor_template(&descriptor_template_buf,
+                                    out,
+                                    sizeof(out),
+                                    WALLET_POLICY_VERSION_V2);
     assert_int_equal(res, 0);
     policy_node_with_script_t *root = (policy_node_with_script_t *) out;
 
@@ -157,10 +177,14 @@ static void test_parse_policy_map_multisig_3(void **state) {
 
     int res;
 
-    char *policy = "sh(wsh(sortedmulti(3,@0/**,@1/**,@2/**,@3/**,@4/**)))";
-    buffer_t policy_buf = buffer_create((void *) policy, strlen(policy));
+    char *descriptor_template = "sh(wsh(sortedmulti(3,@0/**,@1/**,@2/**,@3/**,@4/**)))";
+    buffer_t descriptor_template_buf =
+        buffer_create((void *) descriptor_template, strlen(descriptor_template));
 
-    res = parse_policy_map(&policy_buf, out, sizeof(out), WALLET_POLICY_VERSION_V2);
+    res = parse_descriptor_template(&descriptor_template_buf,
+                                    out,
+                                    sizeof(out),
+                                    WALLET_POLICY_VERSION_V2);
     assert_int_equal(res, 0);
     policy_node_with_script_t *root = (policy_node_with_script_t *) out;
 
@@ -185,7 +209,7 @@ static void test_parse_policy_map_multisig_3(void **state) {
 
 static int parse_policy(char *policy, size_t policy_len, uint8_t *out, size_t out_len) {
     buffer_t in_buf = buffer_create((void *) policy, policy_len);
-    return parse_policy_map(&in_buf, out, out_len, WALLET_POLICY_VERSION_V2);
+    return parse_descriptor_template(&in_buf, out, out_len, WALLET_POLICY_VERSION_V2);
 }
 
 #define PARSE_POLICY(policy, out, out_len) parse_policy(policy, sizeof(policy) - 1, out, out_len)
@@ -253,9 +277,12 @@ static void Test(const char *ms, const char *hexscript, int mode, int opslimit, 
     uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
 
     int res;
-    buffer_t policy_buf = buffer_create((void *) descriptor, strlen(descriptor));
+    buffer_t descriptor_template_buf = buffer_create((void *) descriptor, strlen(descriptor));
 
-    res = parse_policy_map(&policy_buf, out, sizeof(out), WALLET_POLICY_VERSION_V2);
+    res = parse_descriptor_template(&descriptor_template_buf,
+                                    out,
+                                    sizeof(out),
+                                    WALLET_POLICY_VERSION_V2);
 
     if (mode == TESTMODE_INVALID) {
         assert_true(res < 0);


### PR DESCRIPTION
Updates the library to use version 1 of the protocol (from version 2.1.0 of the app).

Unlike the python library, this doesn't try to stay compatible with previous app versions.
It would be possible to extend compatibility to legacy versions of the app; that could be done in a future PR if desired. The library is not currently in use, anyway.

The PR includes some other collateral changes:
- updated Python library and main app's variable names to match the [wallet policies](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020423.html)
- updated Python library to use the new protocol as default, and bumped library version
- added tests of the library with the legacy app to the CI, that was missing
