### PR TITLE
Fixes UX interruptions not working on NanoS+

### DIFF
--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -527,9 +527,11 @@ bool io_ui_process(dispatcher_context_t *context) {
     // We are not waiting for the client's input, nor we are doing computations on the device
     io_clear_processing_timeout();
 
+    io_seproxyhal_general_status();
     do {
         io_seproxyhal_spi_recv(G_io_seproxyhal_spi_buffer, sizeof(G_io_seproxyhal_spi_buffer), 0);
         io_seproxyhal_handle_event();
+        io_seproxyhal_general_status();
     } while (io_seproxyhal_spi_is_status_sent() && !g_ux_flow_ended);
 
     // We're back at work, we want to show the "Processing..." screen when appropriate


### PR DESCRIPTION
#62 introduced a problem that seems only occur on NanoS+ (and not on speculos, so unfortunately not caught by the CI).

Manually tested that this is fixed by adding the calls to `io_seproxyhal_general_status`.

For future reference, the following test failed before the fix on a (LNS+ 1.0.3 device onboarded with the same seed as the test below):

```python
from bitcoin_client.ledger_bitcoin import Client, WalletPolicy
from bitcoin_client.ledger_bitcoin.psbt import PSBT
from test_utils import mnemonic

@mnemonic("neither exist capital focus stumble coil coffee almost then tape husband eager advice win modify unfold rapid magic globe height tone area cactus victory")
def test_sign_psbt_investigate(client: Client):
    # PSBT for a legacy 1-input 1-output spend (no change address)
    psbt_base64 = "cHNidP8BAFICAAAAAcY0GO3kw3WR4DRpjyevAb7hdujw7VJu/c+ri1vFhslFAAAAAAD/////ARD2mQAAAAAAFgAUSBBf5b19pG3O9/HZgTREeBJEmLcAAAAAAAEBH8DYpwAAAAAAFgAUfKscAi6hPq9770PNnBVTCsZ6bM0iBgMOLYv0eQNelPOdulhEVYU53V9ojg5EYm18HTx9uzRcDRipfuaZVAAAgAEAAIAAAACAAAAAAAAAAAAAAA=="
    psbt = PSBT()
    psbt.deserialize(psbt_base64)

    wallet = WalletPolicy(
        "",
        "wpkh(@0/**)",
        [
            "[a97ee699/84'/1'/0']tpubDDWo96oHEBZ2zcCRL6adTB6BtuiLx1AJPZhZHH5zCaXYNSi9n1EQdunqHCM9zWdmQMBHKkqKUdjbEuLCJPHbgydL859z8cYAUMqbDqQFAKF"
        ],
    )

    result = client.sign_psbt(psbt, wallet, None)

    print(result)
```

Closes: #66 