### PR TITLE
Update python client library to support the the Bitcoin Legacy app releases

### DIFF
--- a/bitcoin_client/ledger_bitcoin/client_legacy.py
+++ b/bitcoin_client/ledger_bitcoin/client_legacy.py
@@ -76,7 +76,7 @@ class LegacyClient(Client):
 
         self.app = btchip(DongleAdaptor(comm_client))
 
-        if self.app.getAppName() not in ["Bitcoin", "Bitcoin Test", "app"]:
+        if self.app.getAppName() not in ["Bitcoin", "Bitcoin Legacy", "Bitcoin Test", "Bitcoin Test Legacy", "app"]:
             raise ValueError("Ledger is not in either the Bitcoin or Bitcoin Testnet app")
 
     def get_extended_pubkey(self, path: str, display: bool = False) -> str:

--- a/bitcoin_client/tests/test_client_legacy.py
+++ b/bitcoin_client/tests/test_client_legacy.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from bitcoin_client.ledger_bitcoin import Client
+from bitcoin_client.ledger_bitcoin.client_legacy import LegacyClient
+
+
+tests_root: Path = Path(__file__).parent
+
+
+def test_client_legacy(client: Client):
+    # tests that the library correctly instatiates the LegacyClient and not the new one,
+    # since the version of the app binary being tested is an old one
+    assert isinstance(client, LegacyClient)


### PR DESCRIPTION
Update the library to recognize "Bitcoin Legacy" or "Bitcoin Test Legacy" (see https://github.com/LedgerHQ/app-bitcoin/pull/229) as valid names for the bitcoin app; for those names, the legacy protocol is used _regardless of the app version_.

For the usual names ("Bitcoin", "Bitcoin Test"), we use the legacy protocol if the app version is < 2.1.0. (For simplicity, we still use legacy also for versions at least 2.0.0 and less than 2.1.0, since version 2.1.0 introduced a few upgrades to the new protocol).

Added a test to make sure that the right Client is instantiated; manually tested that it works as expected with "Bitcoin Test Legacy 2.1.0" installed on a device, and fail (as expected) if "Bitcoin Test 2.1.0" is installed.