### PR TITLE
Whitelist m/4541509h/1112098098h for xpub export

### DIFF
--- a/src/handler/get_extended_pubkey.c
+++ b/src/handler/get_extended_pubkey.c
@@ -27,10 +27,19 @@
 #include "../ui/display.h"
 #include "../ui/menu.h"
 
+#define H 0x80000000ul
+
 static bool is_path_safe_for_pubkey_export(const uint32_t bip32_path[],
                                            size_t bip32_path_len,
                                            const uint32_t coin_types[],
                                            size_t coin_types_length) {
+    // Exception for Electrum: it historically used "m/4541509h/1112098098h"
+    // to derive encryption keys, so we whitelist it.
+    if (bip32_path_len == 2 && bip32_path[0] == (4541509 ^ H) &&
+        bip32_path[1] == (1112098098 ^ H)) {
+        return true;
+    }
+
     if (bip32_path_len < 3) {
         return false;
     }


### PR DESCRIPTION
This specific xpub is used by electrum for a disk encryption feature.
We whitelist it to avoid unnecessary warnings to the user.