### PR TITLE
Add missing dependency

### DIFF
--- a/bitcoin_client/CHANGELOG.md
+++ b/bitcoin_client/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are in `dd-mm-yyyy` format.
 
+## [0.1.2] - 09-01-2023
+
+### Fixed
+- Added missing dependency.
+
 ## [0.1.1] - 26-10-2022
 
 ### Changed

--- a/bitcoin_client/ledger_bitcoin/__init__.py
+++ b/bitcoin_client/ledger_bitcoin/__init__.py
@@ -7,7 +7,7 @@ from .common import Chain
 
 from .wallet import AddressType, WalletPolicy, MultisigWallet, WalletType
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 __all__ = [
     "Client",

--- a/bitcoin_client/setup.cfg
+++ b/bitcoin_client/setup.cfg
@@ -16,10 +16,11 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires=
   typing-extensions>=3.7
   ledgercomm>=1.1.0
+  packaging>=21.3
 
 [options.extras_require]
 hid = hidapi>=0.9.0.post3


### PR DESCRIPTION
The dependency to `packaging` was missing.
Also updating minimum python version to 3.7, and bumping version for release.