### PR TITLE
issue 99 fingerprint xpub check and hardened variable check

### DIFF
--- a/bitcoin_client/ledger_bitcoin/client_legacy.py
+++ b/bitcoin_client/ledger_bitcoin/client_legacy.py
@@ -86,6 +86,9 @@ class LegacyClient(Client):
         path = path.replace('h', '\'')
         path = path.replace('H', '\'')
 
+        if 'h' in path:
+            raise ValueError("'h' is not a valid hardened symbol in BIP32 path, only ' is supported")
+
         # This call returns raw uncompressed pubkey, chaincode
         pubkey = self.app.getWalletPublicKey(path, display)
         int_path = parse_path(path)
@@ -104,6 +107,9 @@ class LegacyClient(Client):
         else:
             child = 0
             fpr = b"\x00\x00\x00\x00"
+
+        if(not fpr.islower()):
+            raise ValueError("xpub fingerprint should all be lowercase")
 
         xpub = ExtendedKey(
             version=ExtendedKey.MAINNET_PUBLIC if self.chain == Chain.MAIN else ExtendedKey.TESTNET_PUBLIC,


### PR DESCRIPTION
#99  

Modified client_legacy.py for #99 issue.

Added a check for xpub fingerprints to be lowercase .
added a check yo see path only supports ' and not h as hardened variables .