### PR TITLE
Improve tapscript support in Python library

### DIFF
--- a/bitcoin_client/ledger_bitcoin/__init__.py
+++ b/bitcoin_client/ledger_bitcoin/__init__.py
@@ -1,17 +1,18 @@
 
 """Ledger Nano Bitcoin app client"""
 
-from .client_base import Client, TransportClient
+from .client_base import Client, TransportClient, PartialSignature
 from .client import createClient
 from .common import Chain
 
 from .wallet import AddressType, WalletPolicy, MultisigWallet, WalletType
 
-__version__ = '0.1.2'
+__version__ = '0.2.0'
 
 __all__ = [
     "Client",
     "TransportClient",
+    "PartialSignature",
     "createClient",
     "Chain",
     "AddressType",

--- a/bitcoin_client/tests/test_sign_psbt_legacyapp.py
+++ b/bitcoin_client/tests/test_sign_psbt_legacyapp.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from bitcoin_client.ledger_bitcoin import Client, WalletPolicy
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy, PartialSignature
 
 from bitcoin_client.ledger_bitcoin.psbt import PSBT
 
@@ -42,9 +42,11 @@ def test_sign_psbt_singlesig_pkh_1to1(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"),
-        bytes.fromhex(
-            "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+        PartialSignature(
+            pubkey=bytes.fromhex("02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"),
+            signature=bytes.fromhex(
+                "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+            )
         )
     )]
 
@@ -73,9 +75,11 @@ def test_sign_psbt_singlesig_sh_wpkh_1to2(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("024ba3b77d933de9fa3f9583348c40f3caaf2effad5b6e244ece8abbfcc7244f67"),
-        bytes.fromhex(
-            "30440220720722b08489c2a50d10edea8e21880086c8e8f22889a16815e306daeea4665b02203fcf453fa490b76cf4f929714065fc90a519b7b97ab18914f9451b5a4b45241201"
+        PartialSignature(
+            pubkey=bytes.fromhex("024ba3b77d933de9fa3f9583348c40f3caaf2effad5b6e244ece8abbfcc7244f67"),
+            signature=bytes.fromhex(
+                "30440220720722b08489c2a50d10edea8e21880086c8e8f22889a16815e306daeea4665b02203fcf453fa490b76cf4f929714065fc90a519b7b97ab18914f9451b5a4b45241201"
+            )
         )
     )]
 
@@ -103,9 +107,11 @@ def test_sign_psbt_singlesig_wpkh_1to2(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("03ee2c3d98eb1f93c0a1aa8e5a4009b70eb7b44ead15f1666f136b012ad58d3068"),
-        bytes.fromhex(
-            "3045022100ab44f34dd7e87c9054591297a101e8500a0641d1d591878d0d23cf8096fa79e802205d12d1062d925e27b57bdcf994ecf332ad0a8e67b8fe407bab2101255da632aa01"
+        PartialSignature(
+            pubkey=bytes.fromhex("03ee2c3d98eb1f93c0a1aa8e5a4009b70eb7b44ead15f1666f136b012ad58d3068"),
+            signature=bytes.fromhex(
+                "3045022100ab44f34dd7e87c9054591297a101e8500a0641d1d591878d0d23cf8096fa79e802205d12d1062d925e27b57bdcf994ecf332ad0a8e67b8fe407bab2101255da632aa01"
+            )
         )
     )]
 
@@ -128,14 +134,18 @@ def test_sign_psbt_singlesig_wpkh_2to2(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"),
-        bytes.fromhex(
-            "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+        PartialSignature(
+            pubkey=bytes.fromhex("03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"),
+            signature=bytes.fromhex(
+                "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+            )
         )
     ), (
         1,
-        bytes.fromhex("0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"),
-        bytes.fromhex(
-            "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
-        ),
+        PartialSignature(
+            pubkey=bytes.fromhex("0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"),
+            signature=bytes.fromhex(
+                "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
+            )
+        )
     )]

--- a/doc/bitcoin.md
+++ b/doc/bitcoin.md
@@ -226,7 +226,7 @@ No output data; the signature are returned using the YIELD client command.
 
 #### Description
 
-Using the information in the PSBT and the wallet description, this command verifies what inputs are internal and what output matches the pattern for a change address. After validating all the external outputs and the transaction fee with the user, it signs each of the internal inputs; each signature is sent to the client using the YIELD command, in the format described below. If multiple key placeholders of the wallet policy are internal, the process is repeated for each of them.
+Using the information in the PSBT and the wallet description, this command verifies what inputs are internal and what outputs match the pattern for a change address. After validating all the external outputs and the transaction fee with the user, it signs each of the internal inputs; each signature is sent to the client using the YIELD command, in the format described below. If multiple key placeholders of the wallet policy are internal, the process is repeated for each of them.
 
 The results yielded via the YIELD command respect the following format: `<input_index> <pubkey_augm_len> <pubkey_augm> <signature>`, where:
 - `input_index` is a Bitcoin style varint, the index input of the input being signed (starting from 0);

--- a/tests/test_e2e_miniscript.py
+++ b/tests/test_e2e_miniscript.py
@@ -103,8 +103,8 @@ def run_test_e2e(wallet_policy: WalletPolicy, core_wallet_names: List[str], rpc:
     n_internal_keys = count_internal_keys(speculos_globals.seed, "test", wallet_policy)
     assert len(hww_sigs) == n_internal_keys * len(psbt.inputs)  # should be true as long as all inputs are internal
 
-    for i, pubkey, sig in hww_sigs:
-        psbt.inputs[i].partial_sigs[pubkey] = sig
+    for i, part_sig in hww_sigs:
+        psbt.inputs[i].partial_sigs[part_sig.pubkey] = part_sig.signature
 
     signed_psbt_hww_b64 = psbt.serialize()
 

--- a/tests/test_e2e_multisig.py
+++ b/tests/test_e2e_multisig.py
@@ -102,8 +102,8 @@ def run_test(wallet_policy: WalletPolicy, core_wallet_names: List[str], rpc: Aut
     n_internal_keys = count_internal_keys(speculos_globals.seed, "test", wallet_policy)
     assert len(hww_sigs) == n_internal_keys * len(psbt.inputs)  # should be true as long as all inputs are internal
 
-    for i, pubkey, sig in hww_sigs:
-        psbt.inputs[i].partial_sigs[pubkey] = sig
+    for i, part_sig in hww_sigs:
+        psbt.inputs[i].partial_sigs[part_sig.pubkey] = part_sig.signature
 
     signed_psbt_hww_b64 = psbt.serialize()
 

--- a/tests/test_e2e_tapscripts.py
+++ b/tests/test_e2e_tapscripts.py
@@ -101,18 +101,13 @@ def run_test_e2e(wallet_policy: WalletPolicy, core_wallet_names: List[str], rpc:
         hww_sigs = client.sign_psbt(psbt, wallet_policy, wallet_hmac)
 
     # only correct for taproot policies
-    for i, pubkey_augm, sig in hww_sigs:
-        if len(pubkey_augm) > 33:
+    for i, part_sig in hww_sigs:
+        if part_sig.tapleaf_hash is not None:
             # signature for a script spend
-            assert len(pubkey_augm) == 32 + 32
-            pubkey = pubkey_augm[0:32]
-            leaf_hash = pubkey_augm[32:64]
-            psbt.inputs[i].tap_script_sigs[(pubkey, leaf_hash)] = sig
+            psbt.inputs[i].tap_script_sigs[(part_sig.pubkey, part_sig.tapleaf_hash)] = part_sig.signature
         else:
             # key path spend
-            assert len(pubkey_augm) == 32
-
-            psbt.inputs[i].tap_key_sig = sig
+            psbt.inputs[i].tap_key_sig = part_sig.signature
 
     signed_psbt_hww_b64 = psbt.serialize()
 

--- a/tests/test_sign_psbt.py
+++ b/tests/test_sign_psbt.py
@@ -9,7 +9,7 @@ from typing import List
 
 from pathlib import Path
 
-from bitcoin_client.ledger_bitcoin import Client, WalletPolicy, MultisigWallet, AddressType
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy, MultisigWallet, AddressType, PartialSignature
 from bitcoin_client.ledger_bitcoin.exception.errors import IncorrectDataError, NotSupportedError
 
 from bitcoin_client.ledger_bitcoin.psbt import PSBT
@@ -141,9 +141,11 @@ def test_sign_psbt_singlesig_pkh_1to1(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"),
-        bytes.fromhex(
-            "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+        PartialSignature(
+            pubkey=bytes.fromhex("02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"),
+            signature=bytes.fromhex(
+                "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+            )
         )
     )]
 
@@ -170,9 +172,11 @@ def test_sign_psbt_singlesig_sh_wpkh_1to2(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("024ba3b77d933de9fa3f9583348c40f3caaf2effad5b6e244ece8abbfcc7244f67"),
-        bytes.fromhex(
-            "30440220720722b08489c2a50d10edea8e21880086c8e8f22889a16815e306daeea4665b02203fcf453fa490b76cf4f929714065fc90a519b7b97ab18914f9451b5a4b45241201"
+        PartialSignature(
+            pubkey=bytes.fromhex("024ba3b77d933de9fa3f9583348c40f3caaf2effad5b6e244ece8abbfcc7244f67"),
+            signature=bytes.fromhex(
+                "30440220720722b08489c2a50d10edea8e21880086c8e8f22889a16815e306daeea4665b02203fcf453fa490b76cf4f929714065fc90a519b7b97ab18914f9451b5a4b45241201"
+            )
         )
     )]
 
@@ -200,9 +204,11 @@ def test_sign_psbt_singlesig_wpkh_1to2(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("03ee2c3d98eb1f93c0a1aa8e5a4009b70eb7b44ead15f1666f136b012ad58d3068"),
-        bytes.fromhex(
-            "3045022100ab44f34dd7e87c9054591297a101e8500a0641d1d591878d0d23cf8096fa79e802205d12d1062d925e27b57bdcf994ecf332ad0a8e67b8fe407bab2101255da632aa01"
+        PartialSignature(
+            pubkey=bytes.fromhex("03ee2c3d98eb1f93c0a1aa8e5a4009b70eb7b44ead15f1666f136b012ad58d3068"),
+            signature=bytes.fromhex(
+                "3045022100ab44f34dd7e87c9054591297a101e8500a0641d1d591878d0d23cf8096fa79e802205d12d1062d925e27b57bdcf994ecf332ad0a8e67b8fe407bab2101255da632aa01"
+            )
         )
     )]
 
@@ -233,16 +239,20 @@ def test_sign_psbt_singlesig_wpkh_2to2(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"),
-        bytes.fromhex(
-            "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+        PartialSignature(
+            pubkey=bytes.fromhex("03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"),
+            signature=bytes.fromhex(
+                "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+            )
         )
     ), (
         1,
-        bytes.fromhex("0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"),
-        bytes.fromhex(
-            "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
-        ),
+        PartialSignature(
+            pubkey=bytes.fromhex("0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"),
+            signature=bytes.fromhex(
+                "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
+            ),
+        )
     )]
 
 
@@ -277,16 +287,20 @@ def test_sign_psbt_singlesig_wpkh_2to2_missing_nonwitnessutxo(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"),
-        bytes.fromhex(
-            "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+        PartialSignature(
+            pubkey=bytes.fromhex("03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"),
+            signature=bytes.fromhex(
+                "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+            )
         )
     ), (
         1,
-        bytes.fromhex("0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"),
-        bytes.fromhex(
-            "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
-        ),
+        PartialSignature(
+            pubkey=bytes.fromhex("0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"),
+            signature=bytes.fromhex(
+                "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
+            )
+        )
     )]
 
 
@@ -342,9 +356,11 @@ def test_sign_psbt_multisig_wsh(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("036b16e8c1f979fa4cc0f05b6a300affff941459b6f20de77de55b0160ef8e4cac"),
-        bytes.fromhex(
-            "304402206ab297c83ab66e573723892061d827c5ac0150e2044fed7ed34742fedbcfb26e0220319cdf4eaddff63fc308cdf53e225ea034024ef96de03fd0939b6deeea1e8bd301"
+        PartialSignature(
+            pubkey=bytes.fromhex("036b16e8c1f979fa4cc0f05b6a300affff941459b6f20de77de55b0160ef8e4cac"),
+            signature=bytes.fromhex(
+                "304402206ab297c83ab66e573723892061d827c5ac0150e2044fed7ed34742fedbcfb26e0220319cdf4eaddff63fc308cdf53e225ea034024ef96de03fd0939b6deeea1e8bd301"
+            )
         )
     )]
 
@@ -390,15 +406,16 @@ def test_sign_psbt_taproot_1to2_sighash_all(client: Client):
     # get the (tweaked) pubkey from the scriptPubKey
     pubkey0_psbt = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
 
-    idx0, pubkey0, sig0 = result[0]
+    idx0, partial_sig0 = result[0]
     assert idx0 == 0
-    assert pubkey0 == pubkey0_psbt
+    assert partial_sig0.pubkey == pubkey0_psbt
+    assert partial_sig0.tapleaf_hash is None
 
     # the sighash 0x01 is appended to the signature
-    assert len(sig0) == 64+1
-    assert sig0[-1] == 0x01
+    assert len(partial_sig0.signature) == 64+1
+    assert partial_sig0.signature[-1] == 0x01
 
-    assert bip0340.schnorr_verify(sighash0, pubkey0_psbt, sig0[:-1])
+    assert bip0340.schnorr_verify(sighash0, pubkey0_psbt, partial_sig0.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept.json")
@@ -435,13 +452,14 @@ def test_sign_psbt_taproot_1to2_sighash_default(client: Client):
 
         assert len(result) == 1
 
-        idx0, pubkey0, sig0 = result[0]
+        idx0, partial_sig0 = result[0]
 
         assert idx0 == 0
-        assert pubkey0 == expected_pubkey0
-        assert len(sig0) == 64
+        assert partial_sig0.pubkey == expected_pubkey0
+        assert len(partial_sig0.signature) == 64
+        assert partial_sig0.tapleaf_hash is None
 
-        assert bip0340.schnorr_verify(sighash0, pubkey0, sig0)
+        assert bip0340.schnorr_verify(sighash0, partial_sig0.pubkey, partial_sig0.signature)
 
 
 def test_sign_psbt_singlesig_wpkh_4to3(client: Client, comm: SpeculosClient, is_speculos: bool):
@@ -777,9 +795,11 @@ def test_sign_psbt_singlesig_pkh_1to1_other_encodings(client: Client):
 
         assert result == [(
             0,
-            bytes.fromhex("02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"),
-            bytes.fromhex(
-                "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+            PartialSignature(
+                pubkey=bytes.fromhex("02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"),
+                signature=bytes.fromhex(
+                    "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+                )
             )
         )]
 
@@ -812,16 +832,14 @@ def test_sign_psbt_tr_script_pk_sighash_all(client: Client):
 
     assert len(result) == 1
 
-    idx0, pubkeyaugm0, sig0 = result[0]
-
-    pubkey0 = pubkeyaugm0[0:32]
-    tapleaf_hash0 = pubkeyaugm0[32:]
+    idx0, partial_sig0 = result[0]
 
     assert idx0 == 0
-    assert pubkey0 == bytes.fromhex("6b16e8c1f979fa4cc0f05b6a300affff941459b6f20de77de55b0160ef8e4cac")
-    assert tapleaf_hash0 == bytes.fromhex("092eda033617e210ee7f7d0e378a404aea1c48b56aa103022becf7746e4700a4")
+    assert partial_sig0.pubkey == bytes.fromhex("6b16e8c1f979fa4cc0f05b6a300affff941459b6f20de77de55b0160ef8e4cac")
+    assert partial_sig0.tapleaf_hash == bytes.fromhex(
+        "092eda033617e210ee7f7d0e378a404aea1c48b56aa103022becf7746e4700a4")
 
-    assert len(sig0) == 65
-    assert sig0[-1] == 1  # SIGHASH_ALL
+    assert len(partial_sig0.signature) == 65
+    assert partial_sig0.signature[-1] == 1  # SIGHASH_ALL
 
-    assert bip0340.schnorr_verify(sighash0, pubkey0, sig0[:64])
+    assert bip0340.schnorr_verify(sighash0, partial_sig0.pubkey, partial_sig0.signature[:64])

--- a/tests/test_sign_psbt_v1.py
+++ b/tests/test_sign_psbt_v1.py
@@ -11,7 +11,7 @@ from typing import List
 
 from pathlib import Path
 
-from bitcoin_client.ledger_bitcoin import Client, WalletPolicy, MultisigWallet, AddressType, WalletType
+from bitcoin_client.ledger_bitcoin import Client, WalletPolicy, MultisigWallet, AddressType, WalletType, PartialSignature
 from bitcoin_client.ledger_bitcoin.exception.errors import IncorrectDataError, NotSupportedError
 
 from bitcoin_client.ledger_bitcoin.psbt import PSBT
@@ -144,9 +144,11 @@ def test_sign_psbt_singlesig_pkh_1to1_v1(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"),
-        bytes.fromhex(
-            "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+        PartialSignature(
+            pubkey=bytes.fromhex("02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"),
+            signature=bytes.fromhex(
+                "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+            )
         )
     )]
 
@@ -174,9 +176,11 @@ def test_sign_psbt_singlesig_sh_wpkh_1to2_v1(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("024ba3b77d933de9fa3f9583348c40f3caaf2effad5b6e244ece8abbfcc7244f67"),
-        bytes.fromhex(
-            "30440220720722b08489c2a50d10edea8e21880086c8e8f22889a16815e306daeea4665b02203fcf453fa490b76cf4f929714065fc90a519b7b97ab18914f9451b5a4b45241201"
+        PartialSignature(
+            pubkey=bytes.fromhex("024ba3b77d933de9fa3f9583348c40f3caaf2effad5b6e244ece8abbfcc7244f67"),
+            signature=bytes.fromhex(
+                "30440220720722b08489c2a50d10edea8e21880086c8e8f22889a16815e306daeea4665b02203fcf453fa490b76cf4f929714065fc90a519b7b97ab18914f9451b5a4b45241201"
+            )
         )
     )]
 
@@ -205,9 +209,11 @@ def test_sign_psbt_singlesig_wpkh_1to2_v1(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("03ee2c3d98eb1f93c0a1aa8e5a4009b70eb7b44ead15f1666f136b012ad58d3068"),
-        bytes.fromhex(
-            "3045022100ab44f34dd7e87c9054591297a101e8500a0641d1d591878d0d23cf8096fa79e802205d12d1062d925e27b57bdcf994ecf332ad0a8e67b8fe407bab2101255da632aa01"
+        PartialSignature(
+            pubkey=bytes.fromhex("03ee2c3d98eb1f93c0a1aa8e5a4009b70eb7b44ead15f1666f136b012ad58d3068"),
+            signature=bytes.fromhex(
+                "3045022100ab44f34dd7e87c9054591297a101e8500a0641d1d591878d0d23cf8096fa79e802205d12d1062d925e27b57bdcf994ecf332ad0a8e67b8fe407bab2101255da632aa01"
+            )
         )
     )]
 
@@ -239,16 +245,20 @@ def test_sign_psbt_singlesig_wpkh_2to2_v1(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"),
-        bytes.fromhex(
-            "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+        PartialSignature(
+            pubkey=bytes.fromhex("03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"),
+            signature=bytes.fromhex(
+                "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+            )
         )
     ), (
         1,
-        bytes.fromhex("0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"),
-        bytes.fromhex(
-            "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
-        ),
+        PartialSignature(
+            pubkey=bytes.fromhex("0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"),
+            signature=bytes.fromhex(
+                "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
+            )
+        )
     )]
 
 
@@ -275,9 +285,11 @@ def test_sign_psbt_multisig_wsh_v1(client: Client):
 
     assert result == [(
         0,
-        bytes.fromhex("036b16e8c1f979fa4cc0f05b6a300affff941459b6f20de77de55b0160ef8e4cac"),
-        bytes.fromhex(
-            "304402206ab297c83ab66e573723892061d827c5ac0150e2044fed7ed34742fedbcfb26e0220319cdf4eaddff63fc308cdf53e225ea034024ef96de03fd0939b6deeea1e8bd301"
+        PartialSignature(
+            pubkey=bytes.fromhex("036b16e8c1f979fa4cc0f05b6a300affff941459b6f20de77de55b0160ef8e4cac"),
+            signature=bytes.fromhex(
+                "304402206ab297c83ab66e573723892061d827c5ac0150e2044fed7ed34742fedbcfb26e0220319cdf4eaddff63fc308cdf53e225ea034024ef96de03fd0939b6deeea1e8bd301"
+            )
         )
     )]
 
@@ -310,15 +322,15 @@ def test_sign_psbt_taproot_1to2_v1(client: Client):
     # get the (tweaked) pubkey from the scriptPubKey
     pubkey0_psbt = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
 
-    idx0, pubkey0, sig0 = result[0]
+    idx0, partial_sig0 = result[0]
     assert idx0 == 0
-    assert pubkey0 == pubkey0_psbt
+    assert partial_sig0.pubkey == pubkey0_psbt
 
     # the sighash 0x01 is appended to the signature
-    assert len(sig0) == 64+1
-    assert sig0[-1] == 0x01
+    assert len(partial_sig0.signature) == 64+1
+    assert partial_sig0.signature[-1] == 0x01
 
-    assert bip0340.schnorr_verify(sighash0, pubkey0_psbt, sig0[:-1])
+    assert bip0340.schnorr_verify(sighash0, pubkey0_psbt, partial_sig0.signature[:-1])
 
 
 def test_sign_psbt_singlesig_wpkh_4to3_v1(client: Client, comm: SpeculosClient, is_speculos: bool):

--- a/tests/test_sign_psbt_with_sighash_types.py
+++ b/tests/test_sign_psbt_with_sighash_types.py
@@ -60,16 +60,16 @@ def test_sighash_all_sign_psbt(client: Client):
 
     assert len(result) == 2
 
-    _, _, sig0 = result[0]
-    assert len(sig0) == 64+1
-    assert sig0[-1] == 0x01
+    _, partial_sig0 = result[0]
+    assert len(partial_sig0.signature) == 64+1
+    assert partial_sig0.signature[-1] == 0x01
 
-    _, _, sig1 = result[1]
-    assert len(sig1) == 64+1
-    assert sig1[-1] == 0x01
+    _, partial_sig1 = result[1]
+    assert len(partial_sig1.signature) == 64+1
+    assert partial_sig1.signature[-1] == 0x01
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept.json")
@@ -83,11 +83,11 @@ def test_sighash_all_input_modified(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_1, pubkey1, sig1[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_1, pubkey1, partial_sig1.signature[:-1]) == 0
 
 
 @has_automation("automations/sign_with_default_wallet_accept.json")
@@ -101,11 +101,11 @@ def test_sighash_all_output_modified(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_1, pubkey1, sig1[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_1, pubkey1, partial_sig1.signature[:-1]) == 0
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -120,16 +120,16 @@ def test_sighash_none_sign_psbt(client: Client):
 
     assert len(result) == 2
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert len(sig0) == 64+1
-    assert len(sig1) == 64+1
-    assert sig0[-1] == 0x02
-    assert sig1[-1] == 0x02
+    assert len(partial_sig0.signature) == 64+1
+    assert len(partial_sig1.signature) == 64+1
+    assert partial_sig0.signature[-1] == 0x02
+    assert partial_sig1.signature[-1] == 0x02
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -144,11 +144,11 @@ def test_sighash_none_input_modified(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_1, pubkey1, sig1[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_1, pubkey1, partial_sig1.signature[:-1]) == 0
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -163,11 +163,11 @@ def test_sighash_none_output_modified(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -182,16 +182,16 @@ def test_sighash_single_sign_psbt(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert len(sig0) == 64+1
-    assert len(sig1) == 64+1
-    assert sig0[-1] == 0x03
-    assert sig1[-1] == 0x03
+    assert len(partial_sig0.signature) == 64+1
+    assert len(partial_sig1.signature) == 64+1
+    assert partial_sig0.signature[-1] == 0x03
+    assert partial_sig1.signature[-1] == 0x03
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -207,11 +207,11 @@ def test_sighash_single_input_modified(client: Client):
 
     assert len(result) == 2
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_1, pubkey1, sig1[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_1, pubkey1, partial_sig1.signature[:-1]) == 0
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -227,11 +227,11 @@ def test_sighash_single_output_same_index_modified(client: Client):
 
     assert len(result) == 2
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -247,11 +247,11 @@ def test_sighash_single_output_different_index_modified(client: Client):
 
     assert len(result) == 2
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_1, pubkey1, sig1[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_1, pubkey1, partial_sig1.signature[:-1]) == 0
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -274,16 +274,16 @@ def test_sighash_all_anyone_sign(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert len(sig0) == 64+1
-    assert len(sig1) == 64+1
-    assert sig0[-1] == 0x81
-    assert sig1[-1] == 0x81
+    assert len(partial_sig0.signature) == 64+1
+    assert len(partial_sig1.signature) == 64+1
+    assert partial_sig0.signature[-1] == 0x81
+    assert partial_sig1.signature[-1] == 0x81
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -299,11 +299,11 @@ def test_sighash_all_anyone_input_changed(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -319,11 +319,11 @@ def test_sighash_all_anyone_output_changed(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_1, pubkey1, sig1[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_all_anyone_1, pubkey1, partial_sig1.signature[:-1]) == 0
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -338,16 +338,16 @@ def test_sighash_none_anyone_sign(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert len(sig0) == 64+1
-    assert len(sig1) == 64+1
-    assert sig0[-1] == 0x82
-    assert sig1[-1] == 0x82
+    assert len(partial_sig0.signature) == 64+1
+    assert len(partial_sig1.signature) == 64+1
+    assert partial_sig0.signature[-1] == 0x82
+    assert partial_sig1.signature[-1] == 0x82
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -363,11 +363,11 @@ def test_sighash_none_anyone_input_changed(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -383,11 +383,11 @@ def test_sighash_none_anyone_output_changed(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_none_anyone_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -402,16 +402,16 @@ def test_sighash_single_anyone_sign(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert len(sig0) == 64+1
-    assert len(sig1) == 64+1
-    assert sig0[-1] == 0x83
-    assert sig1[-1] == 0x83
+    assert len(partial_sig0.signature) == 64+1
+    assert len(partial_sig1.signature) == 64+1
+    assert partial_sig0.signature[-1] == 0x83
+    assert partial_sig1.signature[-1] == 0x83
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_0, pubkey0, sig0[:-1])
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_0, pubkey0, partial_sig0.signature[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -427,11 +427,11 @@ def test_sighash_single_anyone_input_changed(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_1, pubkey1, partial_sig1.signature[:-1])
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -447,11 +447,11 @@ def test_sighash_single_anyone_output_changed(client: Client):
     pubkey0 = psbt.inputs[0].witness_utxo.scriptPubKey[2:]
     pubkey1 = psbt.inputs[1].witness_utxo.scriptPubKey[2:]
 
-    _, _, sig0 = result[0]
-    _, _, sig1 = result[1]
+    _, partial_sig0 = result[0]
+    _, partial_sig1 = result[1]
 
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_0, pubkey0, sig0[:-1]) == 0
-    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_1, pubkey1, sig1[:-1])
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_0, pubkey0, partial_sig0.signature[:-1]) == 0
+    assert bip0340.schnorr_verify(sighash_bitcoin_core_single_anyone_1, pubkey1, partial_sig1.signature[:-1])
 
 
 def test_sighash_unsupported(client: Client):
@@ -487,7 +487,7 @@ def test_sighash_segwitv0_sighash1(client: Client):
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
     psbt.inputs[0].sighash = 1
     result = client.sign_psbt(psbt, wpkh_wallet, None)
-    assert result[0][2] == expected_sig
+    assert result[0][1].signature == expected_sig
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -497,7 +497,7 @@ def test_sighash_segwitv0_sighash2(client: Client):
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
     psbt.inputs[0].sighash = 2
     result = client.sign_psbt(psbt, wpkh_wallet, None)
-    assert result[0][2] == expected_sig
+    assert result[0][1].signature == expected_sig
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -507,7 +507,7 @@ def test_sighash_segwitv0_sighash3(client: Client):
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
     psbt.inputs[0].sighash = 3
     result = client.sign_psbt(psbt, wpkh_wallet, None)
-    assert result[0][2] == expected_sig
+    assert result[0][1].signature == expected_sig
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -517,7 +517,7 @@ def test_sighash_segwitv0_sighash81(client: Client):
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
     psbt.inputs[0].sighash = 0x81
     result = client.sign_psbt(psbt, wpkh_wallet, None)
-    assert result[0][2] == expected_sig
+    assert result[0][1].signature == expected_sig
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -527,7 +527,7 @@ def test_sighash_segwitv0_sighash82(client: Client):
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
     psbt.inputs[0].sighash = 0x82
     result = client.sign_psbt(psbt, wpkh_wallet, None)
-    assert result[0][2] == expected_sig
+    assert result[0][1].signature == expected_sig
 
 
 @has_automation("automations/sign_with_default_wallet_accept_nondefault_sighash.json")
@@ -537,4 +537,4 @@ def test_sighash_segwitv0_sighash83(client: Client):
     psbt = open_psbt_from_file(f"{tests_root}/psbt/singlesig/wpkh-1to2.psbt")
     psbt.inputs[0].sighash = 0x83
     result = client.sign_psbt(psbt, wpkh_wallet, None)
-    assert result[0][2] == expected_sig
+    assert result[0][1].signature == expected_sig


### PR DESCRIPTION
On top of #90.
Part of #105.

When signing tapscripts, we now need to return quadruples for each signature the quadruple `input_index`, `pubkey`, `tapleaf_hash`, `signature`, as the `tapleaf_hash` helps identify which leaf containes the pubkey.

(We currently forbid using the exact same pubkey in different leaves because of the restrictions in wallet policies, but it's still more future-proof to return it explicitly, and it probably simplifies integrations substantially).

In order to simplify the type of `sign_psbt` and make future extensions easier and backward-compatible, this PR introduces a new type `PartialSignature` class that contains a `pubkey` and a `signature`, and an optional `tapleaf_hash`.

Therefore, each signature is returned as a pair `(input_index, partial_signature)`.

As this is a breaking change, we increase the version to `0.2.0` from `0.1.x`.

TODO: update Changelog, but we'll need to do it before publishing the new version of the python client.
