### PR TITLE
JS client: Allow importing from bitcoinjs-lib

### DIFF
--- a/bitcoin_client_js/src/lib/psbtv2.ts
+++ b/bitcoin_client_js/src/lib/psbtv2.ts
@@ -436,13 +436,13 @@ export class PsbtV2 {
       if (input.redeemScript)
         this.setInputRedeemScript(index, input.redeemScript);
       psbtBJS.data.inputs[index].bip32Derivation.forEach(derivation => {
-        if (derivation.path.substring(0, 2) !== 'm/')
+        if (!/^m\//i.test(derivation.path))
           throw new Error(`Invalid input bip32 derivation`);
         const pathArray = derivation.path
-          .replace('m/', '')
+          .replace(/m\//i, '')
           .split('/')
           .map(level =>
-            level.match("'") ? parseInt(level) + 0x80000000 : Number(level)
+            level.match(/['h]/i) ? parseInt(level) + 0x80000000 : Number(level)
           );
         this.setInputBip32Derivation(
           index,

--- a/bitcoin_client_js/src/lib/psbtv2.ts
+++ b/bitcoin_client_js/src/lib/psbtv2.ts
@@ -22,7 +22,7 @@ export enum psbtIn {
   PARTIAL_SIG = 0x02,
   SIGHASH_TYPE = 0x03,
   REDEEM_SCRIPT = 0x04,
-  WITNESS_SCRIPT  = 0x05,
+  WITNESS_SCRIPT = 0x05,
   BIP32_DERIVATION = 0x06,
   FINAL_SCRIPTSIG = 0x07,
   FINAL_SCRIPTWITNESS = 0x08,
@@ -114,21 +114,24 @@ export class PsbtV2 {
   }
   setInputWitnessUtxo(
     inputIndex: number,
-    amount: Buffer,
+    amount: number,
     scriptPubKey: Buffer
   ) {
     const buf = new BufferWriter();
-    buf.writeSlice(amount);
+    buf.writeSlice(uint64LE(amount));
     buf.writeVarSlice(scriptPubKey);
     this.setInput(inputIndex, psbtIn.WITNESS_UTXO, b(), buf.buffer());
   }
   getInputWitnessUtxo(
     inputIndex: number
-  ): { readonly amount: Buffer; readonly scriptPubKey: Buffer } | undefined {
+  ): { readonly amount: number; readonly scriptPubKey: Buffer } | undefined {
     const utxo = this.getInputOptional(inputIndex, psbtIn.WITNESS_UTXO, b());
     if (!utxo) return undefined;
     const buf = new BufferReader(utxo);
-    return { amount: buf.readSlice(8), scriptPubKey: buf.readVarSlice() };
+    return {
+      amount: unsafeFrom64bitLE(buf.readSlice(8)),
+      scriptPubKey: buf.readVarSlice()
+    };
   }
   setInputPartialSig(inputIndex: number, pubkey: Buffer, signature: Buffer) {
     this.setInput(inputIndex, psbtIn.PARTIAL_SIG, pubkey, signature);

--- a/bitcoin_client_js/src/lib/psbtv2.ts
+++ b/bitcoin_client_js/src/lib/psbtv2.ts
@@ -387,7 +387,7 @@ export class PsbtV2 {
    * Note: This method supports all the policies that the Ledger is able to
    * sign, with the exception of taproot: tr(@0).
    */
-  fromBitcoinJS(psbtBJS: bjs.Psbt) {
+  fromBitcoinJS(psbtBJS: bjs.Psbt) : PsbtV2 {
     function isTaprootInput(input): boolean {
       let isP2TR;
       try {
@@ -456,6 +456,7 @@ export class PsbtV2 {
       this.setOutputAmount(index, output.value);
       this.setOutputScript(index, output.script);
     });
+    return this;
   }
   private readKeyPair(map: Map<string, Buffer>, buf: BufferReader): boolean {
     const keyLen = sanitizeBigintToNumber(buf.readVarInt());


### PR DESCRIPTION
* Change the type of the amount from `Buffer` to `number` in the methods `setInputWitnessUtxo` and `getInputWitnessUtxo` in the Javascript client code.
* Add a new method in the Javascript client code to import [BitcoinJS PSBT objects](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/ts_src/psbt.ts):

Example Usage:

```javascript
  const ledgerSignatures = await app.signPsbt(
    new PsbtV2().fromBitcoinJS(bjsPsbt),
    ledgerPolicy,
    ledgerPolicyHmac
  );

```

Please note that the method `fromBitcoinJS` has been tested for `wsh(SCRIPT)` expressions, where `SCRIPT` is a miniscript expression (including `older` and `after` policies). However, it does not support Taproot inputs in the PSBT and will throw an error if attempting to import such PSBTs.