### PR TITLE
Expose DefaultDescriptorTemplate

### DIFF
--- a/bitcoin_client_js/src/index.ts
+++ b/bitcoin_client_js/src/index.ts
@@ -1,7 +1,17 @@
 import AppClient from './lib/appClient';
-import { DefaultWalletPolicy, WalletPolicy } from './lib/policy';
+import {
+  DefaultDescriptorTemplate,
+  DefaultWalletPolicy,
+  WalletPolicy
+} from './lib/policy';
 import { PsbtV2 } from './lib/psbtv2';
 
-export { AppClient, PsbtV2, DefaultWalletPolicy, WalletPolicy };
+export {
+  AppClient,
+  PsbtV2,
+  DefaultDescriptorTemplate,
+  DefaultWalletPolicy,
+  WalletPolicy
+};
 
 export default AppClient;


### PR DESCRIPTION
Expose `DefaultDescriptorTemplate` type.
This is necessary to be able to call `DefaultWalletPolicy` using variables (*`as DefaultDescriptorTemplate`*) without typescript errors:

```typescript
    const ledgerSignatures = await ledgerClient.signPsbt(
      new PsbtV2().fromBitcoinJS(psbt),
      new DefaultWalletPolicy(
        ledgerTemplate as DefaultDescriptorTemplate,
        keyRoots[0]!
      ),
      null
    );
```