### PR TITLE
Allow signing wrapped segwit inputs with missing non-witness-utxo

### DIFF
--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -1876,6 +1876,24 @@ int parse_descriptor_template(buffer_t *in_buf, void *out, size_t out_len, int v
     return parse_script(in_buf, &out_buf, version, 0, 0);
 }
 
+int get_policy_segwit_version(const policy_node_t *policy) {
+    if (policy->type == TOKEN_TR) {
+        return 1;
+    } else if (policy->type == TOKEN_SH) {
+        const policy_node_t *inner =
+            resolve_node_ptr(&((const policy_node_with_script_t *) policy)->script);
+        if (inner->type == TOKEN_WPKH || inner->type == TOKEN_WSH) {
+            return 0;  // wrapped segwit
+        } else {
+            return -1;  // legacy
+        }
+    } else if (policy->type == TOKEN_WPKH || policy->type == TOKEN_WSH) {
+        return 0;  // native segwit
+    } else {
+        return -1;  // legacy
+    }
+}
+
 /**
  * Convenience function that returns a + b, except:
  * - returns -1 if any of a and b is negative

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -383,7 +383,7 @@ int parse_policy_map_key_info(buffer_t *buffer, policy_map_key_info_t *out, int 
  * When parsing descriptors containing miniscript, this fails if the miniscript is not correct,
  * as defined by the miniscript type system.
  * This does NOT check non-malleability of the miniscript.
- * * @param in_buf the buffer containing the policy map to parse
+ * @param in_buf the buffer containing the policy map to parse
  * @param out the pointer to the output buffer, which must be 4-byte aligned
  * @param out_len the length of the output buffer
  * @param version either WALLET_POLICY_VERSION_V1 or WALLET_POLICY_VERSION_V2
@@ -391,6 +391,17 @@ int parse_policy_map_key_info(buffer_t *buffer, policy_map_key_info_t *out, int 
  * output buffer is too small.
  */
 int parse_descriptor_template(buffer_t *in_buf, void *out, size_t out_len, int version);
+
+/**
+ * Given a valid policy that the bitcoin app is able to sign, returns the segwit version.
+ * The result is undefined for a node that is not a valid root of a wallet policy that the bitcoin
+ * app is able to sign.
+ *
+ * @param policy the root node of the wallet policy
+ * @return -1 if it's a legacy policy, 0 if it is a policy for SegwitV0 (possibly nested), 1 for
+ * SegwitV1 (taproot).
+ */
+int get_policy_segwit_version(const policy_node_t *policy);
 
 /**
  * Computes additional properties of the given miniscript, to detect malleability and other security

--- a/tests/automations/sign_with_wallet_missing_nonwitnessutxo_accept.json
+++ b/tests/automations/sign_with_wallet_missing_nonwitnessutxo_accept.json
@@ -2,19 +2,43 @@
   "version": 1,
   "rules": [
     {
-      "regexp": "Unverified|Update|or third party|[S]?pend from|Wallet name|Review|Amount|Address|Confirm|Fees",
+      "regexp": "Hold to sign|Confirm wallet name",
       "actions": [
-        ["button", 2, true],
-        ["button", 2, false]
+        ["finger", 55, 550, true]
       ]
     },
     {
-      "regexp": "Continue|Approve|Accept",
+      "regexp": "Processing",
+      "actions": [
+        ["finger", 55, 550, false]
+      ]
+    },
+    {
+      "text": "Approve",
       "actions": [
         [ "button", 1, true ],
         [ "button", 2, true ],
         [ "button", 2, false ],
-        [ "button", 1, false ]
+        [ "button", 1, false ],
+        [ "finger", 55, 550, true]
+      ]
+    },
+    {
+      "regexp": "Continue|Tap to continue|Accept|Warning",
+      "actions": [
+        [ "button", 1, true ],
+        [ "button", 2, true ],
+        [ "button", 2, false ],
+        [ "button", 1, false ],
+        [ "finger", 55, 550, true],
+        [ "finger", 55, 550, false]
+      ]
+    },
+    {
+      "regexp": "Unverified|Update|or third party|[S]?pend from|Wallet name|Review|Amount|Address|Confirm|Fees",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
       ]
     }
   ]

--- a/tests/automations/sign_with_wallet_missing_nonwitnessutxo_accept.json
+++ b/tests/automations/sign_with_wallet_missing_nonwitnessutxo_accept.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "regexp": "Unverified|Update|or third party|[S]?pend from|Wallet name|Review|Amount|Address|Confirm|Fees",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Continue|Approve|Accept",
+      "actions": [
+        [ "button", 1, true ],
+        [ "button", 2, true ],
+        [ "button", 2, false ],
+        [ "button", 1, false ]
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The app allows signing native segwit inputs with missing non-witness-utxo in the PSBT (since version 2.0.6). However, the logic to detect the condition is based on the input's scriptPubKey, rather than the wallet policy. Therefore, wrapped segwit inputs are outright rejected if the non-witness-utxo is missing.

This PR makes the behavior of the app more consistent: for wrapped segwit inputs, a warning is given if the non-witness-utxo is missing, but signing is otherwise still allowed.

Closes: #127