### PR TITLE
Disable relayfee minimums in e2e tests to simplify tx broadcast

### DIFF
--- a/tests/bitcoin.conf
+++ b/tests/bitcoin.conf
@@ -13,3 +13,5 @@ txindex=1
 daemon=1
 debug=1
 fallbackfee=0.00001
+minrelaytxfee=0
+blockmintxfee=0

--- a/tests/test_e2e_miniscript.py
+++ b/tests/test_e2e_miniscript.py
@@ -83,12 +83,8 @@ def run_test_e2e(wallet_policy: WalletPolicy, core_wallet_names: List[str], rpc:
     result = multisig_rpc.walletcreatefundedpsbt(
         outputs={
             out_address: Decimal("0.01")
-        },
-        options={
-            # make sure that the fee is large enough; it looks like
-            # fee estimation doesn't work in core with miniscript, yet
-            "fee_rate": 10
-        })
+        }
+    )
 
     psbt_b64 = result["psbt"]
 

--- a/tests/test_e2e_multisig.py
+++ b/tests/test_e2e_multisig.py
@@ -82,12 +82,8 @@ def run_test(wallet_policy: WalletPolicy, core_wallet_names: List[str], rpc: Aut
     result = multisig_rpc.walletcreatefundedpsbt(
         outputs={
             out_address: Decimal("0.01")
-        },
-        options={
-            # make sure that the fee is large enough; it looks like
-            # fee estimation doesn't work in core with miniscript, yet
-            "fee_rate": 10
-        })
+        }
+    )
 
     psbt_b64 = result["psbt"]
 

--- a/tests/test_e2e_tapscripts.py
+++ b/tests/test_e2e_tapscripts.py
@@ -83,12 +83,8 @@ def run_test_e2e(wallet_policy: WalletPolicy, core_wallet_names: List[str], rpc:
     result = multisig_rpc.walletcreatefundedpsbt(
         outputs={
             out_address: Decimal("0.01")
-        },
-        options={
-            # make sure that the fee is large enough; it looks like
-            # fee estimation doesn't work in core with miniscript, yet
-            "fee_rate": 10
-        })
+        }
+    )
 
     psbt_b64 = result["psbt"]
 


### PR DESCRIPTION
By adding a few settings to the `bitcoin.conf` used in the e2e tests, we can get rid of some ugly and unreliable code to add artificially large fees (we're only interested in transaction validity, anyway).