### PR TITLE
Relax p1 to use it as an optional feature bitmap

### DIFF
--- a/src/boilerplate/dispatcher.c
+++ b/src/boilerplate/dispatcher.c
@@ -127,7 +127,7 @@ void apdu_dispatcher(command_descriptor_t const cmd_descriptors[],
 
     G_dispatcher_context.read_buffer = buffer_create(cmd->data, cmd->lc);
 
-    if (cmd->p1 != 0 || cmd->p2 > 1) {
+    if (cmd->p2 > 1) {
         io_send_sw(SW_WRONG_P1P2);
         return;
     }

--- a/src/boilerplate/dispatcher.c
+++ b/src/boilerplate/dispatcher.c
@@ -127,7 +127,7 @@ void apdu_dispatcher(command_descriptor_t const cmd_descriptors[],
 
     G_dispatcher_context.read_buffer = buffer_create(cmd->data, cmd->lc);
 
-    if (cmd->p2 > 1) {
+    if (cmd->p2 > CURRENT_PROTOCOL_VERSION) {
         io_send_sw(SW_WRONG_P1P2);
         return;
     }

--- a/src/constants.h
+++ b/src/constants.h
@@ -6,6 +6,11 @@
 #define CLA_APP 0xE1
 
 /**
+ * Encodes the protocol version, which is passed in the p2 field of APDUs.
+ */
+#define CURRENT_PROTOCOL_VERSION 1
+
+/**
  * Maximum length of a serialized address (in characters).
  * Segwit addresses can reach 74 characters; 76 on regtest because of the longer "bcrt" prefix.
  */

--- a/src/handler/get_extended_pubkey.c
+++ b/src/handler/get_extended_pubkey.c
@@ -114,8 +114,8 @@ static bool is_path_safe_for_pubkey_export(const uint32_t bip32_path[],
     return true;
 }
 
-void handler_get_extended_pubkey(dispatcher_context_t *dc, uint8_t p2) {
-    (void) p2;
+void handler_get_extended_pubkey(dispatcher_context_t *dc, uint8_t protocol_version) {
+    (void) protocol_version;
 
     LOG_PROCESSOR(__FILE__, __LINE__, __func__);
 

--- a/src/handler/get_master_fingerprint.c
+++ b/src/handler/get_master_fingerprint.c
@@ -24,8 +24,8 @@
 
 #include "handlers.h"
 
-void handler_get_master_fingerprint(dispatcher_context_t *dc, uint8_t p2) {
-    (void) p2;
+void handler_get_master_fingerprint(dispatcher_context_t *dc, uint8_t protocol_version) {
+    (void) protocol_version;
 
     // Device must be unlocked
     if (os_global_pin_is_validated() != BOLOS_UX_OK) {

--- a/src/handler/get_wallet_address.c
+++ b/src/handler/get_wallet_address.c
@@ -42,8 +42,8 @@
 #include "handlers.h"
 #include "client_commands.h"
 
-void handler_get_wallet_address(dispatcher_context_t *dc, uint8_t p2) {
-    (void) p2;
+void handler_get_wallet_address(dispatcher_context_t *dc, uint8_t protocol_version) {
+    (void) protocol_version;
 
     LOG_PROCESSOR(__FILE__, __LINE__, __func__);
 

--- a/src/handler/register_wallet.c
+++ b/src/handler/register_wallet.c
@@ -50,8 +50,8 @@ static bool is_policy_name_acceptable(const char *name, size_t name_len);
  * Validates the input, initializes the hash context and starts accumulating the wallet header in
  * it.
  */
-void handler_register_wallet(dispatcher_context_t *dc, uint8_t p2) {
-    (void) p2;
+void handler_register_wallet(dispatcher_context_t *dc, uint8_t protocol_version) {
+    (void) protocol_version;
 
     LOG_PROCESSOR(__FILE__, __LINE__, __func__);
 

--- a/src/handler/sign_message.c
+++ b/src/handler/sign_message.c
@@ -34,8 +34,8 @@ static unsigned char const BSM_SIGN_MAGIC[] = {'\x18', 'B', 'i', 't', 'c', 'o', 
                                                'S',    'i', 'g', 'n', 'e', 'd', ' ', 'M', 'e',
                                                's',    's', 'a', 'g', 'e', ':', '\n'};
 
-void handler_sign_message(dispatcher_context_t *dc, uint8_t p2) {
-    (void) p2;
+void handler_sign_message(dispatcher_context_t *dc, uint8_t protocol_version) {
+    (void) protocol_version;
 
     uint8_t bip32_path_len;
     uint32_t bip32_path[MAX_BIP32_PATH_STEPS];

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -139,7 +139,7 @@ typedef struct {
 
     bool is_wallet_canonical;
 
-    uint8_t p2;
+    uint8_t protocol_version;
 
     union {
         uint8_t wallet_policy_map_bytes[MAX_WALLET_POLICY_BYTES];
@@ -1845,7 +1845,7 @@ static bool __attribute__((noinline)) yield_signature(dispatcher_context_t *dc,
     uint8_t augm_pubkey_len = pubkey_len + (tapleaf_hash != NULL ? 32 : 0);
 
     // the pubkey is not output in version 0 of the protocol
-    if (st->p2 >= 1) {
+    if (st->protocol_version >= 1) {
         dc->add_to_response(&augm_pubkey_len, 1);
         dc->add_to_response(pubkey, pubkey_len);
 
@@ -2474,7 +2474,7 @@ sign_transaction(dispatcher_context_t *dc,
     return true;
 }
 
-void handler_sign_psbt(dispatcher_context_t *dc, uint8_t p2) {
+void handler_sign_psbt(dispatcher_context_t *dc, uint8_t protocol_version) {
     LOG_PROCESSOR(__FILE__, __LINE__, __func__);
 
     sign_psbt_state_t st;
@@ -2486,7 +2486,7 @@ void handler_sign_psbt(dispatcher_context_t *dc, uint8_t p2) {
         return;
     }
 
-    st.p2 = p2;
+    st.protocol_version = protocol_version;
 
     // read APDU inputs, intialize global state and read global PSBT map
     if (!init_global_state(dc, &st)) return;

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,18 @@
+import pytest
+
+from bitcoin_client.ledger_bitcoin import Client
+from bitcoin_client.ledger_bitcoin.client_base import ApduException
+from bitcoin_client.ledger_bitcoin.command_builder import BitcoinCommandBuilder, BitcoinInsType, CURRENT_PROTOCOL_VERSION
+
+
+def test_p2_too_high(client: Client):
+    # Tests that sending a p2 > CURRENT_PROTOCOL_VERSION fails with 0x6a86 (WRONG_P1P2)
+    with pytest.raises(ApduException, match="Exception: invalid status 0x6a86"):
+        # We can't use the client to send this apdu, so we use raw transport
+        client.transport_client.apdu_exchange(
+            cla=BitcoinCommandBuilder.CLA_BITCOIN,
+            ins=BitcoinInsType.GET_MASTER_FINGERPRINT,
+            p1=0,
+            p2=CURRENT_PROTOCOL_VERSION + 1,
+            data=b''
+        )

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -5,6 +5,21 @@ from bitcoin_client.ledger_bitcoin.client_base import ApduException
 from bitcoin_client.ledger_bitcoin.command_builder import BitcoinCommandBuilder, BitcoinInsType, CURRENT_PROTOCOL_VERSION
 
 
+def test_high_p1_allowed(client: Client):
+    # We reserve p1 for feature flags, so non-zero bits shouldn't be rejected
+    # for forward-compatibility; this allows graceful degradation for optional features.
+
+    # We can't use the client to send this apdu, so we use raw transport.
+    # We're only testing that no exception is raised.
+    client.transport_client.apdu_exchange(
+        cla=BitcoinCommandBuilder.CLA_BITCOIN,
+        ins=BitcoinInsType.GET_MASTER_FINGERPRINT,
+        p1=0xff,
+        p2=CURRENT_PROTOCOL_VERSION,
+        data=b''
+    )
+
+
 def test_p2_too_high(client: Client):
     # Tests that sending a p2 > CURRENT_PROTOCOL_VERSION fails with 0x6a86 (WRONG_P1P2)
     with pytest.raises(ApduException, match="Exception: invalid status 0x6a86"):


### PR DESCRIPTION
For some future use cases, it might be useful to have some additional optional features that can be activated by a client that supports them, but do not otherwise disrupt the normal flow of operations.

The `p1` APDU field is currently unused and forced to be 0.
By relaxing the requirement and ignoring the value of `p1` we guarantee that such optional features can be added without breaking forward-compatibility or forcing a protocol version upgrade (which instead uses the `p2`field).

I also added a test to make sure that a `p2` value higher than the current protocol version is rejected; for the protocol version we prefer explicit opt-in, instead − it would generally be used for more drastic breaking changes to the protocol.