### PR TITLE
Reject policies that are not correctly implemented in certain app versions

### DIFF
--- a/bitcoin_client/CHANGELOG.md
+++ b/bitcoin_client/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are in `dd-mm-yyyy` format.
 
+## [0.2.1] - 18-04-2023
+
+### Changed
+- Avoid using miniscript policies containing an `a:` fragment on versions below `2.1.2` of the bitcoin app.
+
+## [0.2.0] - 3-04-2023
+
+This release introduces a breaking change in the return type of the `sign_psbt`method.
+
+### Added
+- Added new `PartialSignature` data class together with support for taproot script signing, which is supported in version `2.1.2` of the bitcoin app.
+
 ## [0.1.2] - 09-01-2023
 
 ### Fixed

--- a/bitcoin_client/ledger_bitcoin/__init__.py
+++ b/bitcoin_client/ledger_bitcoin/__init__.py
@@ -7,7 +7,7 @@ from .common import Chain
 
 from .wallet import AddressType, WalletPolicy, MultisigWallet, WalletType
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 __all__ = [
     "Client",

--- a/bitcoin_client_js/package.json
+++ b/bitcoin_client_js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledger-bitcoin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Ledger Hardware Wallet Bitcoin Application Client",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/bitcoin_client_js/src/__tests__/appClient.test.ts
+++ b/bitcoin_client_js/src/__tests__/appClient.test.ts
@@ -128,6 +128,11 @@ describe("test AppClient", () => {
     await killProcess(sp);
   });
 
+  it("can retrieve the app's version", async () => {
+    const result = await app.getAppAndVersion();
+    expect(result.name).toEqual("Bitcoin Test");
+    expect(result.version.split(".")[0]).toEqual("2")
+  });
 
   it("can retrieve the master fingerprint", async () => {
     const result = await app.getMasterFingerprint();

--- a/bitcoin_client_rs/Cargo.toml
+++ b/bitcoin_client_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_bitcoin_client"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Edouard Paris <m@edouard.paris>"]
 edition = "2018"
 description = "Ledger Bitcoin application client"

--- a/bitcoin_client_rs/src/client.rs
+++ b/bitcoin_client_rs/src/client.rs
@@ -18,7 +18,7 @@ use crate::{
     error::BitcoinClientError,
     interpreter::{get_merkleized_map_commitment, ClientCommandInterpreter},
     psbt::*,
-    wallet::WalletPolicy,
+    wallet::{contains_a, WalletPolicy},
 };
 
 /// BitcoinClient calls and interprets commands with the Ledger Device.
@@ -61,6 +61,18 @@ impl<T: Transport> BitcoinClient<T> {
         } else {
             Ok(data)
         }
+    }
+
+    fn validate_policy(&self, wallet: &WalletPolicy) -> Result<(), BitcoinClientError<T::Error>> {
+        if contains_a(&wallet.descriptor_template) {
+            let (_, version, _) = self.get_version()?;
+            if version == "2.1.0" || version == "2.1.1" {
+                // Versions 2.1.0 and 2.1.1 produced incorrect scripts for policies containing
+                // the `a:` fragment.
+                return Err(BitcoinClientError::UnsupportedAppVersion);
+            }
+        }
+        Ok(())
     }
 
     /// Returns the currently running app's name, version and state flags
@@ -129,6 +141,8 @@ impl<T: Transport> BitcoinClient<T> {
         &self,
         wallet: &WalletPolicy,
     ) -> Result<([u8; 32], [u8; 32]), BitcoinClientError<T::Error>> {
+        self.validate_policy(&wallet)?;
+
         let cmd = command::register_wallet(wallet);
         let mut intpr = ClientCommandInterpreter::new();
         intpr.add_known_preimage(wallet.serialize());
@@ -162,6 +176,8 @@ impl<T: Transport> BitcoinClient<T> {
         address_index: u32,
         display: bool,
     ) -> Result<bitcoin::Address, BitcoinClientError<T::Error>> {
+        self.validate_policy(&wallet)?;
+
         let mut intpr = ClientCommandInterpreter::new();
         intpr.add_known_preimage(wallet.serialize());
         let keys: Vec<String> = wallet.keys.iter().map(|k| k.to_string()).collect();
@@ -188,6 +204,8 @@ impl<T: Transport> BitcoinClient<T> {
         wallet: &WalletPolicy,
         wallet_hmac: Option<&[u8; 32]>,
     ) -> Result<Vec<(usize, PublicKey, EcdsaSig)>, BitcoinClientError<T::Error>> {
+        self.validate_policy(&wallet)?;
+
         let mut intpr = ClientCommandInterpreter::new();
         intpr.add_known_preimage(wallet.serialize());
         let keys: Vec<String> = wallet.keys.iter().map(|k| k.to_string()).collect();

--- a/bitcoin_client_rs/src/error.rs
+++ b/bitcoin_client_rs/src/error.rs
@@ -9,6 +9,7 @@ pub enum BitcoinClientError<T: Debug> {
     Interpreter(InterpreterError),
     Device { command: u8, status: StatusWord },
     UnexpectedResult { command: u8, data: Vec<u8> },
+    UnsupportedAppVersion,
 }
 
 impl<T: Debug> From<InterpreterError> for BitcoinClientError<T> {


### PR DESCRIPTION
As a conservative measure against running miniscript-based wallets with versions of the app affected by the bug fixed in f9673ef7dc5f4b4bcde4f62e44e1c7df4dc803de (versions 2.1.0 and 2.1.1), this PR modifies the python, JS and Rust client to reject operating in any command using a wallet policy if both the following conditions are true:
- the descriptor template contains the `a:` wrapper
- the app version is either `2.1.0` or `2.1.1`.

Incidentally, added a public `getAppAndVersion` method to the JS client library to get the running app name and version, which is available in other clients and could be useful to improve client side support in integrations.