### PR TITLE
Fixes for thresh fragment

### DIFF
--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -988,7 +988,7 @@ static int parse_script(buffer_t *in_buf,
                 return WITH_ERROR(-1, "children of and_n must be miniscript");
             }
 
-            // and_n(X, Y) is equivalent to andor(X, Y, 1)
+            // and_n(X, Y) is equivalent to andor(X, Y, 0)
             // X is Bdu; Y is B
 
             const policy_node_t *X = resolve_node_ptr(&node->scripts[0]);
@@ -1118,7 +1118,7 @@ static int parse_script(buffer_t *in_buf,
             node->base.flags.is_miniscript = 1;
             node->base.flags.miniscript_type = MINISCRIPT_TYPE_V;
             node->base.flags.miniscript_mod_z = X->flags.miniscript_mod_z & Z->flags.miniscript_mod_z;
-            node->base.flags.miniscript_mod_o = X->flags.miniscript_mod_o & Z->flags.miniscript_mod_o;
+            node->base.flags.miniscript_mod_o = X->flags.miniscript_mod_o & Z->flags.miniscript_mod_z;
             node->base.flags.miniscript_mod_n = 0;
             node->base.flags.miniscript_mod_d = 0;
             node->base.flags.miniscript_mod_u = 0;

--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -1343,8 +1343,8 @@ static int parse_script(buffer_t *in_buf,
             node->base.flags.miniscript_mod_z = (count_z == node->n) ? 1 : 0;
             node->base.flags.miniscript_mod_o = (count_z == node->n - 1 && count_o == 1) ? 1 : 0;
             node->base.flags.miniscript_mod_n = 0;
-            node->base.flags.miniscript_mod_d = 0;
-            node->base.flags.miniscript_mod_u = 0;
+            node->base.flags.miniscript_mod_d = 1;
+            node->base.flags.miniscript_mod_u = 1;
             // clang-format on
 
             break;

--- a/tests/test_e2e_miniscript.py
+++ b/tests/test_e2e_miniscript.py
@@ -275,6 +275,36 @@ def test_e2e_miniscript_me_or_3of5(rpc, rpc_test_wallet, client: Client, speculo
     run_test_e2e(wallet_policy, [], rpc, rpc_test_wallet, client, speculos_globals, comm)
 
 
+def test_e2e_miniscript_me_large_vault(rpc, rpc_test_wallet, client: Client, speculos_globals: SpeculosGlobals, comm: Union[TransportClient, SpeculosClient], model: str):
+    if (model == "nanos"):
+        pytest.skip("Not supported on Nano S due to memory limitations")
+
+    path = "48'/1'/0'/2'"
+    _, core_xpub_orig1 = create_new_wallet()
+    _, core_xpub_orig2 = create_new_wallet()
+    _, core_xpub_orig3 = create_new_wallet()
+    _, core_xpub_orig4 = create_new_wallet()
+    _, core_xpub_orig5 = create_new_wallet()
+    _, core_xpub_orig6 = create_new_wallet()
+    internal_xpub = get_internal_xpub(speculos_globals.seed, path)
+    internal_xpub_orig = f"[{speculos_globals.master_key_fingerprint.hex()}/{path}]{internal_xpub}"
+
+    wallet_policy = WalletPolicy(
+        name="Large vault",
+        descriptor_template="wsh(or_d(pk(@0/**),andor(thresh(1,utv:thresh(1,pkh(@1/**),a:pkh(@2/**)),autv:thresh(1,pkh(@3/**),a:pkh(@4/**))),after(1685577600),and_v(v:and_v(v:pkh(@5/**),thresh(1,pkh(@6/**))),after(1685318400)))))",
+        keys_info=[
+            internal_xpub_orig,
+            f"{core_xpub_orig1}",
+            f"{core_xpub_orig2}",
+            f"{core_xpub_orig3}",
+            f"{core_xpub_orig4}",
+            f"{core_xpub_orig5}",
+            f"{core_xpub_orig6}",
+        ])
+
+    run_test_e2e(wallet_policy, [], rpc, rpc_test_wallet, client, speculos_globals, comm)
+
+
 def test_e2e_miniscript_me_and_bob_or_me_and_carl_1(rpc, rpc_test_wallet, client: Client, speculos_globals: SpeculosGlobals, comm: Union[TransportClient, SpeculosClient]):
     # policy: or(and(pk(A1), pk(B)),and(pk(A2), pk(C)))
     # where A1 and A2 are both internal keys; therefore, two signatures per input must be returned


### PR DESCRIPTION
Fixes two errors in the implementation of `thresh`:
- It was missing the 'd' and 'u' properties, which caused some valid miniscript to be rejected as invalid
- It had a spurious OP_ADD in the uncommon `thresh(1, X)` case. (Normally, one would just use `X` directly, so it shouldn't happen in practice).

Another mistake was also fixed in `or_c` (compare with [specs](https://bitcoin.sipa.be/miniscript/)), and a wrong comment in the code of `and_n`.