### PR TITLE
Declare type annotations

### DIFF
--- a/bitcoin_client/setup.cfg
+++ b/bitcoin_client/setup.cfg
@@ -22,6 +22,9 @@ install_requires=
   ledgercomm>=1.1.0
   packaging>=21.3
 
+[options.package_data]
+* = py.typed
+
 [options.extras_require]
 hid = hidapi>=0.9.0.post3
 


### PR DESCRIPTION
The Python module is statically typed, but does not export the type information. This adds the `py.typed` marker as per PEP 561.