### PR TITLE
Replace PR #184: Validate Generated Addresses Against Expected Ones in JS Client Library

### DIFF
--- a/bitcoin_client_js/package.json
+++ b/bitcoin_client_js/package.json
@@ -29,9 +29,11 @@
     "node": ">=14"
   },
   "dependencies": {
+    "@bitcoinerlab/descriptors": "^1.0.2",
+    "@bitcoinerlab/secp256k1": "^1.0.5",
     "@ledgerhq/hw-transport": "^6.20.0",
     "bip32-path": "^0.4.2",
-    "bitcoinjs-lib": "^6.0.1"
+    "bitcoinjs-lib": "^6.1.3"
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-speculos-http": "^6.24.1",

--- a/bitcoin_client_js/package.json
+++ b/bitcoin_client_js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledger-bitcoin",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Ledger Hardware Wallet Bitcoin Application Client",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/bitcoin_client_js/src/__tests__/appClient.test.ts
+++ b/bitcoin_client_js/src/__tests__/appClient.test.ts
@@ -260,6 +260,36 @@ describe("test AppClient", () => {
     expect(walletHmac.length).toEqual(32);
   });
 
+  //https://wizardsardine.com/blog/ledger-vulnerability-disclosure/
+  it('can generate a correct address or throw on a:X', async () => {
+    try {
+      const walletPolicy = new WalletPolicy('Fixed Vulnerability', 'wsh(and_b(pk(@0/**),a:1))', [
+        "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P"
+      ]);
+
+      const automation = JSON.parse(fs.readFileSync('src/__tests__/automations/register_wallet_accept.json').toString());
+      await setSpeculosAutomation(transport, automation);
+
+      const [walletId, walletHmac] = await app.registerWallet(walletPolicy);
+
+      expect(walletId).toEqual(walletPolicy.getId());
+      expect(walletHmac.length).toEqual(32);
+
+      const address = await app.getWalletAddress(
+        walletPolicy,
+        walletHmac,
+        0,
+        0,
+        false
+      );
+      //version > 2.1.1
+      expect(address).toEqual('tb1q5lyn9807ygs7pc52980mdeuwl9wrq5c8n3kntlhy088h6fqw4gzspw9t9m');
+    } catch (error) {
+      //version <= 2.1.1
+      expect(error.message).toMatch(/^Third party address validation mismatch/);
+    }
+  });
+
   it("can register a miniscript wallet", async () => {
     const walletPolicy = new WalletPolicy(
       "Decaying 3-of-3",

--- a/bitcoin_client_js/src/__tests__/appClient.test.ts
+++ b/bitcoin_client_js/src/__tests__/appClient.test.ts
@@ -262,31 +262,46 @@ describe("test AppClient", () => {
 
   //https://wizardsardine.com/blog/ledger-vulnerability-disclosure/
   it('can generate a correct address or throw on a:X', async () => {
-    try {
-      const walletPolicy = new WalletPolicy('Fixed Vulnerability', 'wsh(and_b(pk(@0/**),a:1))', [
-        "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P"
-      ]);
+    for (const template of [
+      'wsh(and_b(pk(@0/**),a:1))',
+      'wsh(and_b(pk(@0/<0;1>/*),a:1))'
+    ]) {
+      try {
+        const walletPolicy = new WalletPolicy('Fixed Vulnerability', template, [
+          "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P"
+        ]);
 
-      const automation = JSON.parse(fs.readFileSync('src/__tests__/automations/register_wallet_accept.json').toString());
-      await setSpeculosAutomation(transport, automation);
+        const automation = JSON.parse(
+          fs
+            .readFileSync(
+              'src/__tests__/automations/register_wallet_accept.json'
+            )
+            .toString()
+        );
+        await setSpeculosAutomation(transport, automation);
 
-      const [walletId, walletHmac] = await app.registerWallet(walletPolicy);
+        const [walletId, walletHmac] = await app.registerWallet(walletPolicy);
 
-      expect(walletId).toEqual(walletPolicy.getId());
-      expect(walletHmac.length).toEqual(32);
+        expect(walletId).toEqual(walletPolicy.getId());
+        expect(walletHmac.length).toEqual(32);
 
-      const address = await app.getWalletAddress(
-        walletPolicy,
-        walletHmac,
-        0,
-        0,
-        false
-      );
-      //version > 2.1.1
-      expect(address).toEqual('tb1q5lyn9807ygs7pc52980mdeuwl9wrq5c8n3kntlhy088h6fqw4gzspw9t9m');
-    } catch (error) {
-      //version <= 2.1.1
-      expect(error.message).toMatch(/^Third party address validation mismatch/);
+        const address = await app.getWalletAddress(
+          walletPolicy,
+          walletHmac,
+          0,
+          0,
+          false
+        );
+        //version > 2.1.1
+        expect(address).toEqual(
+          'tb1q5lyn9807ygs7pc52980mdeuwl9wrq5c8n3kntlhy088h6fqw4gzspw9t9m'
+        );
+      } catch (error) {
+        //version <= 2.1.1
+        expect(error.message).toMatch(
+          /^Third party address validation mismatch/
+        );
+      }
     }
   });
 

--- a/bitcoin_client_js/src/lib/appClient.ts
+++ b/bitcoin_client_js/src/lib/appClient.ts
@@ -441,8 +441,9 @@ export class AppClient {
     }
     // Replace index:
     expression = expression.replace(/\/\*/g, `/${addressIndex}`);
-    // Replace origin:
-    for (let i = 0; i < walletPolicy.keys.length; i++)
+    // Replace origin in reverse order to prevent
+    // misreplacements, e.g., @10 being mistaken for @1 and leaving a 0.
+    for (let i = walletPolicy.keys.length - 1; i >= 0; i--)
       expression = expression.replace(
         new RegExp(`@${i}`, 'g'),
         walletPolicy.keys[i]

--- a/bitcoin_client_js/src/lib/appClient.ts
+++ b/bitcoin_client_js/src/lib/appClient.ts
@@ -407,7 +407,7 @@ export class AppClient {
     return result.toString('base64');
   }
 
-  /* Performs any additional check on the genetated address before returning it.*/
+  /* Performs any additional check on the generated address before returning it.*/
   private async validateAddress(
     address: string,
     walletPolicy: WalletPolicy,


### PR DESCRIPTION
This PR replaces the earlier PR #184, which had issues due to a faulty rebase operation. Like the previous one, it aims to address issue #171 by implementing an enhanced validation method in the JavaScript client library. It validates the generated wallet addresses against the expected ones using the "@bitcoinerlab/descriptors" library. Here are the key updates:

1. Updated package.json to incorporate new dependencies "@bitcoinerlab/descriptors" and "@bitcoinerlab/secp256k1", and the latest version of "bitcoinjs-lib" to "^6.1.3".

2. Introduced a new test in appClient.test.ts to validate the generated address or throw an error if it doesn't match the expected one.

3. Made modifications in appClient.ts to integrate new imports. Changes have been made to the `AppClient` class to use these libraries for address validation. Some previous validations were removed as they are now handled more effectively with the new approach.

In response to the review comments on the previous PR, I've:

* Bumped the package version to 0.2.3.
* Added address validation at the end of `registerWallet`.
* Completely replaced `validatePolicy` with `validateAddress` and removed `containsA`.
* Adjusted the code for correctly parsing the `<M;N>` format. Included a test case using this format for better clarity.

For further context and details, please refer to the discussion and changes in the previous PR #184.