### PR TITLE
Use image compiled the latest bitcoin-core instead of a custom fork

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,14 +1,30 @@
 # An image derived from ledgerhq/speculos but also containing the bitcoin-core binaries
+# compiled from the master branch
 
 FROM ghcr.io/ledgerhq/speculos:latest
 
-# install curl
-RUN apt update -y && apt install -y curl
+# install git and curl
+RUN apt update -y && apt install -y git curl
 
-# download bitcoin-core and decompress it to /bitcoin
-RUN curl -o /tmp/bitcoin.tar.gz https://bitcoin.org/bin/bitcoin-core-22.0/bitcoin-22.0-x86_64-linux-gnu.tar.gz && \
-    tar -xf /tmp/bitcoin.tar.gz -C / && \
-    mv /bitcoin-22.0 /bitcoin
+# install autotools bitcoin-core build dependencies
+RUN apt install -y automake autotools-dev bsdmainutils build-essential ccache git libboost-dev libboost-filesystem-dev libboost-system-dev libboost-test-dev libevent-dev libminiupnpc-dev libnatpmp-dev libqt5gui5 libqt5core5a libqt5dbus5 libsqlite3-dev libtool libzmq3-dev pkg-config python3 qttools5-dev qttools5-dev-tools qtwayland5 systemtap-sdt-dev
+
+# clone bitcoin-core from github and compile it
+RUN cd / && \
+    git clone https://github.com/bitcoin/bitcoin.git && \
+    cd bitcoin && \
+    ./autogen.sh && \
+    ./configure --enable-suppress-external-warnings && \
+    make -j "$(($(nproc)+1))" && \
+    mkdir bin && \
+    cp src/bitcoind src/bitcoin-cli src/bitcoin-tx src/bitcoin-util src/bitcoin-wallet ./bin
+
+
+FROM ghcr.io/ledgerhq/speculos:latest
+COPY --from=0 /bitcoin/bin /bitcoin/bin
+
+# install runtime dependencies for bitcoind
+RUN apt update -y && apt install -y libminiupnpc-dev libminiupnpc-dev libnatpmp-dev libevent-dev libzmq3-dev
 
 # Add bitcoin binaries to path
 ENV PATH=/bitcoin/bin:$PATH

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin-custom:latest
+      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin:latest
       ports:
         - 1234:1234
         - 9999:9999
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin-custom:latest
+      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin:latest
       ports:
         - 1234:1234
         - 9999:9999
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin-custom:latest
+      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin:latest
       ports:
         - 1234:1234
         - 9999:9999
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin-custom:latest
+      image: ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin:latest
       ports:
         - 1234:1234
         - 9999:9999


### PR DESCRIPTION
Now that bitcoin-core has full miniscript support, we no longer need to use a custom branch for e2e tests.