### PR TITLE
Fix test with 512 inputs

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -163,9 +163,10 @@ static size_t cx_hash_ripemd160(const uint8_t *in, size_t in_len, uint8_t *out, 
     if (out_len < CX_RIPEMD160_SIZE) {
         return 0;
     }
-    cx_ripemd160_init_no_throw((cx_ripemd160_t *) &G_cx);
-    cx_ripemd160_update((cx_ripemd160_t *) &G_cx, in, in_len);
-    cx_ripemd160_final((cx_ripemd160_t *) &G_cx, out);
+    LEDGER_ASSERT(cx_ripemd160_init_no_throw((cx_ripemd160_t *) &G_cx) == CX_OK, "It never fails");
+    LEDGER_ASSERT(cx_ripemd160_update((cx_ripemd160_t *) &G_cx, in, in_len) == CX_OK,
+                  "It never fails");
+    LEDGER_ASSERT(cx_ripemd160_final((cx_ripemd160_t *) &G_cx, out) == CX_OK, "It never fails");
     explicit_bzero((cx_ripemd160_t *) &G_cx, sizeof(cx_sha256_t));
     return CX_RIPEMD160_SIZE;
 }

--- a/test_utils/txmaker.py
+++ b/test_utils/txmaker.py
@@ -198,9 +198,9 @@ def createPsbt(wallet: WalletPolicy, input_amounts: List[int], output_amounts: L
             psbt.inputs[i].hd_keypaths[input_key] = KeyOriginInfo(
                 master_key_fpr, path)
         elif is_taproot:
-            tweaked_key = get_taproot_output_key(input_key)
-            psbt.inputs[i].tap_bip32_paths[tweaked_key] = (
-                list(), KeyOriginInfo(master_key_fpr, path))
+            internal_key = input_key[1:]
+            psbt.inputs[i].tap_bip32_paths[internal_key] = (
+                {}, KeyOriginInfo(master_key_fpr, path))
         else:
             raise RuntimeError("Unexpected state: unknown transaction type")
 
@@ -224,12 +224,12 @@ def createPsbt(wallet: WalletPolicy, input_amounts: List[int], output_amounts: L
                 psbt.outputs[i].hd_keypaths[output_key] = KeyOriginInfo(
                     master_key_fpr, path)
             elif is_taproot:
-                tweaked_key = get_taproot_output_key(output_key)
-                psbt.outputs[i].tap_bip32_paths[tweaked_key] = (
-                    list(), KeyOriginInfo(master_key_fpr, path))
+                internal_key = output_key[1:]
+                psbt.outputs[i].tap_bip32_paths[internal_key] = (
+                    {}, KeyOriginInfo(master_key_fpr, path))
 
-                psbt.outputs[i].tap_bip32_paths[tweaked_key] = (
-                    list(), KeyOriginInfo(master_key_fpr, path))
+                psbt.outputs[i].tap_bip32_paths[internal_key] = (
+                    {}, KeyOriginInfo(master_key_fpr, path))
 
     psbt.tx = tx
 

--- a/tests/test_sign_psbt_v1.py
+++ b/tests/test_sign_psbt_v1.py
@@ -481,39 +481,6 @@ def test_sign_psbt_singlesig_large_amount_v1(client: Client, comm: SpeculosClien
     assert parsed_events["amounts"][0] == format_amount(CURRENCY_TICKER, out_amt)
 
 
-@pytest.mark.timeout(0)  # disable timeout
-@has_automation("automations/sign_with_default_wallet_accept.json")
-def test_sign_psbt_singlesig_wpkh_512to256_v1(client: Client, enable_slow_tests: bool):
-    # PSBT for a transaction with 512 inputs and 256 outputs (maximum currently supported in the app)
-    # Very slow test (esp. with DEBUG enabled), so disabled unless the --enableslowtests option is used
-
-    if not enable_slow_tests:
-        pytest.skip()
-
-    n_inputs = 512
-    n_outputs = 256
-
-    wallet = WalletPolicy(
-        "",
-        "tr(@0)",
-        [
-            "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U/**"
-        ],
-        version=WalletType.WALLET_POLICY_V1
-    )
-
-    psbt = txmaker.createPsbt(
-        wallet,
-        [10000 + 10000 * i for i in range(n_inputs)],
-        [999 + 99 * i for i in range(n_outputs)],
-        [i == 42 for i in range(n_outputs)]
-    )
-
-    result = client.sign_psbt(psbt, wallet, None)
-
-    assert len(result) == n_inputs
-
-
 def ux_thread_accept_prompt_stax(speculos_client: SpeculosClient, all_events: List[dict]):
     """Completes the signing flow always going right and accepting at the appropriate time, while collecting all the events in all_events."""
 


### PR DESCRIPTION
The `txmaker` tool was incorrectly filling the psbt for this test (which is not ran as part of the CI, as it's extremely slow).
Moreover, the mock transaction amounts triggered the warning introduced in #196.

Minor refactoring and fixed some typos.

Deleted the corresponding test in the old `v1` test suite, not worth the burden of keeping both.