### PR TITLE
Add APPVERSION_SUFFIX in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,13 @@ PATH_SLIP21_APP_LOAD_PARAMS = "LEDGER-Wallet policy"
 APPVERSION_M = 2
 APPVERSION_N = 2
 APPVERSION_P = 0
-APPVERSION   = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
+APPVERSION_SUFFIX = # if not empty, appended at the end. Do not add a dash.
+
+ifeq ($(APPVERSION_SUFFIX),)
+APPVERSION = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
+else
+APPVERSION = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)-$(strip $(APPVERSION_SUFFIX))"
+endif
 
 # Setting to allow building variant applications
 VARIANT_PARAM = COIN


### PR DESCRIPTION
Small improvement in `Makefile` to make it easier to tag beta releases.