### PR TITLE
Fix tapleaf hash computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are in `dd-mm-yyyy` format.
 
+## [2.2.1] - 18-03-2024
+
+### Fixed
+
+- Signing failure for certain taproot policies in versions 2.1.2, 2.1.3 and 2.2.0: returned tapleaf hashes (and corresponding signatures) are incorrect if the descriptor template has a derivation path not ending for `/**` or `/<0;1>/*` for that key.
+
 ## [2.2.0] - 29-01-2024
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ PATH_SLIP21_APP_LOAD_PARAMS = "LEDGER-Wallet policy"
 # Application version
 APPVERSION_M = 2
 APPVERSION_N = 2
-APPVERSION_P = 0
+APPVERSION_P = 1
 APPVERSION   = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
 
 # Setting to allow building variant applications

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -2354,10 +2354,6 @@ fill_taproot_placeholder_info(dispatcher_context_t *dc,
                               const input_info_t *input,
                               const policy_node_t *tapleaf_ptr,
                               placeholder_info_t *placeholder_info) {
-    uint32_t change = input->in_out.is_change ? placeholder_info->placeholder.num_second
-                                              : placeholder_info->placeholder.num_first;
-    uint32_t address_index = input->in_out.address_index;
-
     cx_sha256_t hash_context;
     crypto_tr_tapleaf_hash_init(&hash_context);
 
@@ -2369,8 +2365,8 @@ fill_taproot_placeholder_info(dispatcher_context_t *dc,
         &(wallet_derivation_info_t){.wallet_version = st->wallet_header_version,
                                     .keys_merkle_root = st->wallet_header_keys_info_merkle_root,
                                     .n_keys = st->wallet_header_n_keys,
-                                    .change = change,
-                                    .address_index = address_index},
+                                    .change = input->in_out.is_change,
+                                    .address_index = input->in_out.address_index},
         WRAPPED_SCRIPT_TYPE_TAPSCRIPT,
         NULL);
     if (tapscript_len < 0) {
@@ -2389,8 +2385,8 @@ fill_taproot_placeholder_info(dispatcher_context_t *dc,
             &(wallet_derivation_info_t){.wallet_version = st->wallet_header_version,
                                         .keys_merkle_root = st->wallet_header_keys_info_merkle_root,
                                         .n_keys = st->wallet_header_n_keys,
-                                        .change = change,
-                                        .address_index = address_index},
+                                        .change = input->in_out.is_change,
+                                        .address_index = input->in_out.address_index},
             WRAPPED_SCRIPT_TYPE_TAPSCRIPT,
             &hash_context.header)) {
         return false;  // should never happen!


### PR DESCRIPTION
Fixes an issue reported by @wizardsardine: signing fails in taproot policies for keys that have derivations not ending with `/<0;1>/*`, due to the wrong derivation path being used during the computation of the tapleaf hash at signing time.

Prepares release 2.2.1 to release the fix asap.