### PR TITLE
Fix `signMessage` failing for messages of certain lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are in `dd-mm-yyyy` format.
 
+## [2.2.5] - TBD
+
+### Fixed
+
+- `signMessage` would fail since version 2.2.2 for certain message lengths.
+
 ## [2.2.4] - 09-07-2024
 
 ### Changed

--- a/src/handler/sign_message.c
+++ b/src/handler/sign_message.c
@@ -56,7 +56,13 @@ static bool display_message_content_and_confirm(dispatcher_context_t* dc,
 
         total_chunk_len += offset;
 
-        for (int j = 0; j < MESSAGE_CHUNK_PER_DISPLAY; j++) {
+        // each UX display will show MESSAGE_CHUNK_PER_DISPLAY chunks
+        size_t group_start_index = get_streaming_index() * MESSAGE_CHUNK_PER_DISPLAY;
+
+        for (int j = 0;
+             j < MESSAGE_CHUNK_PER_DISPLAY &&
+             (group_start_index + j) < (unsigned int) n_chunks;  // make sure not to overflow
+             j++) {
             offset += j * MESSAGE_CHUNK_SIZE;
 
             int chunk_len =

--- a/tests/instructions.py
+++ b/tests/instructions.py
@@ -4,15 +4,15 @@ from ragger.firmware import Firmware
 from ragger_bitcoin.ragger_instructions import Instructions
 
 
-def message_instruction_approve(model: Firmware) -> Instructions:
+def message_instruction_approve(model: Firmware, save_screenshot=True) -> Instructions:
     instructions = Instructions(model)
 
     if model.name.startswith("nano"):
-        instructions.nano_skip_screen("Path")
-        instructions.same_request("Sign")
+        instructions.nano_skip_screen("Path", save_screenshot=save_screenshot)
+        instructions.same_request("Sign", save_screenshot=save_screenshot)
     else:
-        instructions.review_message()
-        instructions.confirm_message()
+        instructions.review_message(save_screenshot=save_screenshot)
+        instructions.confirm_message(save_screenshot=save_screenshot)
 
     return instructions
 

--- a/tests/test_sign_message.py
+++ b/tests/test_sign_message.py
@@ -19,6 +19,15 @@ def test_sign_message(navigator: Navigator, firmware: Firmware, client: RaggerCl
     assert result == "IOR4YRVlmJGMx+H7PgQvHzWAF0HAgrUggQeRdnoWKpypfaAberpvF+XbOCM5Cd/ljogNyU3w2OIL8eYCyZ6Ru2k="
 
 
+def test_sign_message_64bytes(navigator: Navigator, firmware: Firmware, client: RaggerClient, test_name: str):
+    # Version 2.2.2 introduced a bug where signing a 64 bytes message would fail; this test is to avoid regressions
+    msg = "a" * 64
+    path = "m/44'/1'/0'/0/0"
+    client.sign_message(msg, path, navigator,
+                        instructions=message_instruction_approve(firmware, save_screenshot=False),
+                        testname=test_name)
+
+
 def test_sign_message_accept(navigator: Navigator, firmware: Firmware, client: RaggerClient, test_name: str):
     message = "Hello world!"
 


### PR DESCRIPTION
A bug present since version 2.2.2 makes `signMessage` fail for certain message lengths, due to an overflow in the requests to the client in the new UX for arbitrary message lengths.