### PR TITLE
Update instructions about dependencies to install before running tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,6 +4,12 @@ These tests are implemented in Python and can be executed either using the [Spec
 
 All the commands in this folder are meant to be ran from the `tests` folder, not from the root.
 
+Install the following system dependencies:
+
+```
+sudo apt-get install -y python3-pytest autoconf automake build-essential libffi-dev libtool pkg-config python3-dev
+```
+
 Python dependencies are listed in [requirements.txt](../requirements.txt), install them using [pip](https://pypi.org/project/pip/) from the root of the repository:
 
 ```


### PR DESCRIPTION
Noticed while tying to run tests on a new machine.