### PR TITLE
Harden unsafe function

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -275,11 +275,17 @@ uint32_t crypto_get_master_key_fingerprint() {
 }
 
 bool crypto_derive_symmetric_key(const char *label, size_t label_len, uint8_t key[static 32]) {
-    // TODO: is there a better way?
-    //       The label is a byte string in SLIP-0021, but os_derive_bip32_with_seed_no_throw
-    //       accesses the `path` argument as an array of uint32_t, causing a device freeze if memory
-    //       is not aligned.
+    // The label is a byte string in SLIP-0021, but os_derive_bip32_with_seed_no_throw
+    // accesses the `path` argument as an array of uint32_t, causing a device freeze if memory
+    // is not aligned.
+    // As a workaround, we copy the label into a local buffer aligned to 4 bytes.
+
     uint8_t label_copy[32] __attribute__((aligned(4)));
+
+    // Fail if the length of the buffer is longer than the local buffer
+    if (label_len > sizeof(label_copy)) {
+        return false;
+    }
 
     memcpy(label_copy, label, label_len);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -300,7 +300,7 @@ int get_extended_pubkey_at_path(const uint32_t bip32_path[],
  * @param[in]  label
  *   Pointer to the label. The first byte of the label must be 0x00 to comply with SLIP-0021.
  * @param[in]  label_len
- *   Length of the label.
+ *   Length of the label. It must be at most 32 bytes.
  * @param[out] key
  *   Pointer to a 32-byte output buffer that will contain the generated key.
  */

--- a/src/handler/register_wallet.c
+++ b/src/handler/register_wallet.c
@@ -250,7 +250,10 @@ void handler_register_wallet(dispatcher_context_t *dc, uint8_t protocol_version)
     //       And the signature would be on the concatenation of the wallet id and the metadata.
     //       The client must persist the metadata, together with the signature.
 
-    compute_wallet_hmac(wallet_id, response.hmac);
+    if (!compute_wallet_hmac(wallet_id, response.hmac)) {
+        SEND_SW(dc, SW_BAD_STATE);  // this should never fail
+        return;
+    }
 
     SEND_RESPONSE(dc, &response, sizeof(response), SW_OK);
 }

--- a/src/handler/register_wallet.c
+++ b/src/handler/register_wallet.c
@@ -241,15 +241,6 @@ void handler_register_wallet(dispatcher_context_t *dc, uint8_t protocol_version)
 
     memcpy(response.wallet_id, wallet_id, sizeof(wallet_id));
 
-    // TODO: we might want to add external info to be committed with the signature (e.g.: app
-    // version).
-    //       This would allow newer versions of the app to invalidate an old signature if desired,
-    //       for example if a vulnerability is discovered in the registration flow of a previous
-    //       app. The response would be changed to:
-    //         <wallet_id> <metadata_len> <metadata> <hmac>
-    //       And the signature would be on the concatenation of the wallet id and the metadata.
-    //       The client must persist the metadata, together with the signature.
-
     if (!compute_wallet_hmac(wallet_id, response.hmac)) {
         SEND_SW(dc, SW_BAD_STATE);  // this should never fail
         return;


### PR DESCRIPTION
The function `crypto_derive_symmetric_key` is dangerously written, as it has potential for buffer overflows. It is only used in a safe way with a fixed constant in the code, but it is better to be conservative and prevent possible future problems.