### PR TITLE
Moving the ticker to the end for the swap case

### DIFF
--- a/src/swap/handle_get_printable_amount.c
+++ b/src/swap/handle_get_printable_amount.c
@@ -5,21 +5,25 @@
 
 #include "btchip_bcd.h"
 
+#define MAX_NON_PRINTABLE_AMOUNT_LEN 8
+
 int handle_get_printable_amount(get_printable_amount_parameters_t *params) {
     params->printable_amount[0] = 0;
-    if (params->amount_length > 8) {
+    if (params->amount_length > MAX_NON_PRINTABLE_AMOUNT_LEN) {
         PRINTF("Amount is too big");
         return 0;
     }
-    unsigned char amount[8];
-    memset(amount, 0, 8);
-    memcpy(amount + (8 - params->amount_length), params->amount, params->amount_length);
+    unsigned char amount[MAX_NON_PRINTABLE_AMOUNT_LEN] = {0};
+    /* Amount + ' ' + ticker */
+    memcpy(amount + (MAX_NON_PRINTABLE_AMOUNT_LEN - params->amount_length),
+           params->amount,
+           params->amount_length);
+    int res_length =
+        btchip_convert_hex_amount_to_displayable_no_globals(amount,
+                                                            (uint8_t *) params->printable_amount);
+    params->printable_amount[res_length] = ' ';
     size_t coin_name_length = strlen(COIN_COINID_SHORT);
-    memmove(params->printable_amount, COIN_COINID_SHORT, coin_name_length);
-    params->printable_amount[coin_name_length] = ' ';
-    int res_length = btchip_convert_hex_amount_to_displayable_no_globals(
-        amount,
-        (uint8_t *) params->printable_amount + coin_name_length + 1);
+    memmove(&params->printable_amount[res_length + 1], COIN_COINID_SHORT, coin_name_length);
     params->printable_amount[res_length + coin_name_length + 1] = '\0';
 
     return 1;


### PR DESCRIPTION
Linked to https://github.com/LedgerHQ/app-exchange/pull/329, need to decide on a better merge order. 

- [x] App update process has been followed
- [x] Target branch is develop
- [x] will bump it in a separate PR having collected enough changes for a new release 
- [x] to remove temporary commits switching to `swap_ticker_move` branch of app-exchange


Successful swap test (but Apex Plus) with swap workflow redirected to https://github.com/LedgerHQ/app-exchange/tree/swap_ticker_move branch: https://github.com/LedgerHQ/app-bitcoin-new/actions/runs/18905486909.

