### PR TITLE
Fix speculos-bitcoin image in CI

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -21,8 +21,11 @@ RUN cd / && \
 FROM ghcr.io/ledgerhq/speculos:latest
 COPY --from=0 /usr/local/bin/ /usr/local/bin/
 
+# install essential tools
+RUN apt update -y && apt install -y build-essential curl git
+
 # install runtime dependencies for bitcoind
-RUN apt update -y && apt install -y libminiupnpc-dev libminiupnpc-dev libnatpmp-dev libevent-dev libzmq3-dev
+RUN apt install -y libminiupnpc-dev libminiupnpc-dev libnatpmp-dev libevent-dev libzmq3-dev
 
 # Add bitcoin binaries to path
 ENV PATH=/usr/local/bin/:$PATH

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -13,7 +13,7 @@ RUN apt install -y bsdmainutils build-essential cmake pkg-config ccache git libb
 RUN cd / && \
     git clone --depth=1 https://github.com/bitcoin/bitcoin.git && \
     cd bitcoin && \
-    cmake -B build && \
+    cmake -B build -DENABLE_IPC=OFF && \
     cmake --build build && \
     cmake --install build
 

--- a/.github/workflows/build_and_functional_tests.yml
+++ b/.github/workflows/build_and_functional_tests.yml
@@ -41,7 +41,7 @@ jobs:
     uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_ragger_tests.yml@v1
     with:
       download_app_binaries_artifact: "compiled_app_binaries"
-      container_image: "ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin-musig2:latest"
+      container_image: "ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin:latest"
       # when merging a PR, we run the tests with the --enable_slow_tests parameter
       test_options: ${{ github.event_name == 'push' && '--enable_slow_tests' || '' }}
       regenerate_snapshots: ${{ github.event_name == 'workflow_dispatch' && inputs.golden_run == 'Open a PR' }}

--- a/tests/test_e2e_miniscript.py
+++ b/tests/test_e2e_miniscript.py
@@ -82,7 +82,7 @@ def run_test_e2e(navigator: Navigator, client: RaggerClient, wallet_policy: Wall
     rpc_test_wallet.sendtoaddress(T(address_hww), "0.1")
     generate_blocks(1)
 
-    assert multisig_rpc.getwalletinfo()["balance"] == Decimal("0.1")
+    assert multisig_rpc.getbalances()["mine"]["trusted"] == Decimal("0.1")
 
     # ==> prepare a psbt spending from the wallet
 

--- a/tests/test_e2e_multisig.py
+++ b/tests/test_e2e_multisig.py
@@ -82,7 +82,7 @@ def run_test(navigator: Navigator, client: RaggerClient, wallet_policy: WalletPo
     rpc_test_wallet.sendtoaddress(T(address_hww), "0.1")
     generate_blocks(1)
 
-    assert multisig_rpc.getwalletinfo()["balance"] == Decimal("0.1")
+    assert multisig_rpc.getbalances()["mine"]["trusted"] == Decimal("0.1")
 
     # ==> prepare a psbt spending from the multisig wallet
 

--- a/tests/test_e2e_musig2.py
+++ b/tests/test_e2e_musig2.py
@@ -98,7 +98,7 @@ def run_test_e2e_musig2(navigator: Navigator, client: RaggerClient, wallet_polic
     rpc_test_wallet.sendtoaddress(T(address_hww), "0.1")
     generate_blocks(1)
 
-    assert core_wallet_rpc.getwalletinfo()["balance"] == Decimal("0.1")
+    assert core_wallet_rpc.getbalances()["mine"]["trusted"] == Decimal("0.1")
 
     # ==> prepare a psbt spending from the wallet
 

--- a/tests/test_e2e_tapscripts.py
+++ b/tests/test_e2e_tapscripts.py
@@ -80,7 +80,7 @@ def run_test_e2e(navigator: Navigator, client: RaggerClient, wallet_policy: Wall
     rpc_test_wallet.sendtoaddress(T(address_hww), "0.1")
     generate_blocks(1)
 
-    assert multisig_rpc.getwalletinfo()["balance"] == Decimal("0.1")
+    assert multisig_rpc.getbalances()["mine"]["trusted"] == Decimal("0.1")
 
     # ==> prepare a psbt spending from the wallet
 


### PR DESCRIPTION
Fix the build of the `speculos-bitcoin` container image (that was missing some dependencies), and stops using the `speculos-bitcoin-musig2` image in the CI: that is no longer necessary since MuSig2 support is merged in [bitcoin-core](https://github.com/bitcoin/bitcoin) master.

It also fixes the usage of the rpc in e2e tests, using the `getbalances` RPC in replacement of the `getwalletinfo` rpc (whose 'balance' field has been removed).

Closes: #312