### PR TITLE
Parse unknown yielded tags in python client for sign_psbt

### DIFF
--- a/bitcoin_client/ledger_bitcoin/__init__.py
+++ b/bitcoin_client/ledger_bitcoin/__init__.py
@@ -1,7 +1,7 @@
 
 """Ledger Nano Bitcoin app client"""
 
-from .client_base import Client, TransportClient, PartialSignature, MusigPubNonce, MusigPartialSignature, SignPsbtYieldedObject
+from .client_base import Client, TransportClient, PartialSignature, MusigPubNonce, MusigPartialSignature, SignPsbtYieldedObject, UnknownSignPsbtYieldedObject
 from .client import createClient
 from .common import Chain
 
@@ -16,6 +16,7 @@ __all__ = [
     "MusigPubNonce",
     "MusigPartialSignature",
     "SignPsbtYieldedObject",
+    "UnknownSignPsbtYieldedObject",
     "createClient",
     "Chain",
     "AddressType",

--- a/bitcoin_client/ledger_bitcoin/client.py
+++ b/bitcoin_client/ledger_bitcoin/client.py
@@ -11,7 +11,7 @@ from .embit.networks import NETWORKS
 from .command_builder import BitcoinCommandBuilder, BitcoinInsType
 from .common import Chain, read_uint, read_varint
 from .client_command import ClientCommandInterpreter, CCMD_YIELD_MUSIG_PARTIALSIGNATURE_TAG, CCMD_YIELD_MUSIG_PUBNONCE_TAG
-from .client_base import Client, MusigPartialSignature, MusigPubNonce, SignPsbtYieldedObject, TransportClient, PartialSignature
+from .client_base import Client, MusigPartialSignature, MusigPubNonce, SignPsbtYieldedObject, UnknownSignPsbtYieldedObject, TransportClient, PartialSignature
 from .client_legacy import LegacyClient
 from .exception import DeviceException
 from .errors import UnknownDeviceError
@@ -145,6 +145,11 @@ def _decode_signpsbt_yielded_value(res: bytes) -> Tuple[int, SignPsbtYieldedObje
                 partial_signature=partial_signature
             )
         )
+    elif input_index_or_tag >= 0x80000000:
+        # this is certainly an unknown tag added by a future version of the app
+        # we expect the first element to be the input index, and the rest of the data is opaque
+        input_index = read_varint(res_buffer)
+        return input_index, UnknownSignPsbtYieldedObject(input_index_or_tag, res_buffer.read())
     else:
         # other values follow an encoding without an explicit tag, where the
         # first element is the input index. All the signature types are implemented

--- a/bitcoin_client/ledger_bitcoin/client_base.py
+++ b/bitcoin_client/ledger_bitcoin/client_base.py
@@ -120,8 +120,18 @@ class MusigPartialSignature:
     partial_signature: bytes
 
 
+@dataclass(frozen=True)
+class UnknownSignPsbtYieldedObject:
+    """Represents an unknown object returned by sign_psbt, for forward compatibility.
+
+    It contains the tag and the opaque bytes returned by the device.
+    """
+    tag: int
+    data: bytes
+
+
 SignPsbtYieldedObject = Union[PartialSignature,
-                              MusigPubNonce, MusigPartialSignature]
+                              MusigPubNonce, MusigPartialSignature, UnknownSignPsbtYieldedObject]
 
 
 class Client:


### PR DESCRIPTION
This allows future-proofing the client by returning an explicit unknown yielded value (that can safely be logged/ignored) instead of returning an incorrect enormous 'input index'.

The Rust client uses the same approach.