### PR TITLE
Consistently use version 1 for the protocol version in JS client

### DIFF
--- a/bitcoin_client_js/src/lib/appClient.ts
+++ b/bitcoin_client_js/src/lib/appClient.ts
@@ -102,7 +102,7 @@ export class AppClient {
         CLA_FRAMEWORK,
         FrameworkIns.CONTINUE_INTERRUPTED,
         0,
-        0,
+        CURRENT_PROTOCOL_VERSION,
         commandResponse,
         [0x9000, 0xe000]
       );


### PR DESCRIPTION
While the protocol version is ignored in the app on `INS=CONTINUE_INTERRUPTED` apdus, both the python and the Rust client consistently use version 1 for all APDUs.
There is no reason for the JS client to behave differently.