### PR TITLE
Add missing length validation for V2 wallet policies

### DIFF
--- a/src/handler/lib/policy.c
+++ b/src/handler/lib/policy.c
@@ -348,6 +348,9 @@ int read_and_parse_wallet_policy(
         if (descriptor_template_len < 0) {
             return WITH_ERROR(-1, "Failed getting wallet policy descriptor template");
         }
+        if ((size_t) descriptor_template_len != wallet_header->descriptor_template_len) {
+            return WITH_ERROR(-1, "Descriptor template length mismatch");
+        }
     }
 
     buffer_t policy_map_buffer =


### PR DESCRIPTION
With V2 wallet policies, the preimage of the wallet policy is requested after the wallet policy header, which already declares its length. Therefore, the length of the preimage should always match.

Thanks to Rob Hamilton @Rob1Ham for the [bug report](https://github.com/Rob1Ham/app-bitcoin-new/pull/4).