### PR TITLE
Disable `musig` in key expressions of `musig_a`/`sortedmulti_a`

### DIFF
--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -437,7 +437,7 @@ int parse_policy_map_key_info(buffer_t *buffer, policy_map_key_info_t *out, int 
  * - Single key index:
  *   - @IDX/**
  *   - @IDX/<M;N>/*
- * - MuSig2 aggregate key (only if is_taproot is true):
+ * - MuSig2 aggregate key (only if allow_musig is true):
  *   - musig(@IDX,@IDX,...,@IDX)/**
  *   - musig(@IDX,@IDX,...,@IDX)/<M;N>/*
  * where IDX is a key index.
@@ -446,7 +446,7 @@ int parse_policy_map_key_info(buffer_t *buffer, policy_map_key_info_t *out, int 
 static int parse_keyexpr(buffer_t *in_buf,
                          int version,
                          policy_node_keyexpr_t *out,
-                         bool is_taproot,
+                         bool allow_musig,
                          buffer_t *out_buf,
                          uint16_t *keyexpr_index) {
     char c;
@@ -469,7 +469,7 @@ static int parse_keyexpr(buffer_t *in_buf,
             return WITH_ERROR(-1, "Expected musig key expression");
         }
 
-        if (!is_taproot) {
+        if (!allow_musig) {
             return WITH_ERROR(-1, "musig is only allowed in taproot");
         }
 
@@ -1525,7 +1525,7 @@ static int parse_script(buffer_t *in_buf,
             if (0 > parse_keyexpr(in_buf,
                                   version,
                                   key_expr,
-                                  is_taproot,
+                                  is_taproot,  // musig is only allowed in taproot
                                   out_buf,
                                   &key_expression_count)) {
                 return WITH_ERROR(-1, "Couldn't parse key expression");
@@ -1597,6 +1597,7 @@ static int parse_script(buffer_t *in_buf,
             }
             i_policy_node_keyexpr(&node->key, key_expr);
 
+            // the taproot internal key can be a musig
             if (0 >
                 parse_keyexpr(in_buf, version, key_expr, true, out_buf, &key_expression_count)) {
                 return WITH_ERROR(-1, "Couldn't parse key expression");
@@ -1712,7 +1713,9 @@ static int parse_script(buffer_t *in_buf,
             node->k = (int16_t) k;
 
             // We allocate the array of key indices at the current position in the output buffer
-            // (on success)
+            // (on success).
+            // Note: this is incompatible with musig keys, therefore we don't currently support
+            // musig nested inside multi_a or sortedmulti_a.
             buffer_alloc(out_buf, 0, true);  // ensure alignment of current pointer
             i_policy_node_keyexpr(&node->keys, buffer_get_cur(out_buf));
 
@@ -1738,12 +1741,14 @@ static int parse_script(buffer_t *in_buf,
                     return WITH_ERROR(-1, "Out of memory");
                 }
 
-                if (0 > parse_keyexpr(in_buf,
-                                      version,
-                                      key_expr,
-                                      is_taproot,
-                                      out_buf,
-                                      &key_expression_count)) {
+                if (0 >
+                    parse_keyexpr(
+                        in_buf,
+                        version,
+                        key_expr,
+                        false,  // musig is not currently supported in keys of multisig fragments
+                        out_buf,
+                        &key_expression_count)) {
                     return WITH_ERROR(-1, "Error parsing key expression");
                 }
 

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -398,7 +398,7 @@ typedef struct {
     uint16_t k;                 // threshold
     uint16_t n;                 // number of child scripts
     rptr_policy_node_scriptlist_t
-        scriptlist;  // pointer to array of exactly n pointers to child scripts
+        scriptlist;  // pointer to a linked list of exactly n child scripts
 } policy_node_thresh_t;
 
 typedef struct {

--- a/unit-tests/test_wallet.c
+++ b/unit-tests/test_wallet.c
@@ -300,7 +300,7 @@ static void test_parse_policy_tr_musig_keypath(void **state) {
     assert_int_equal(root->base.type, TOKEN_TR);
     assert_true(isnull_policy_node_tree(&root->tree));
 
-    check_key_expr_musig(r_policy_node_keyexpr(&root->key), 3, (uint16_t[]){2, 0, 1}, 3, 13);
+    check_key_expr_musig(r_policy_node_keyexpr(&root->key), 3, (uint16_t[]) {2, 0, 1}, 3, 13);
 }
 
 static void test_parse_policy_tr_musig_scriptpath(void **state) {
@@ -324,7 +324,7 @@ static void test_parse_policy_tr_musig_scriptpath(void **state) {
     policy_node_with_key_t *script_pk = (policy_node_with_key_t *) r_policy_node(&tree->script);
     assert_int_equal(script_pk->base.type, TOKEN_PK);
 
-    check_key_expr_musig(r_policy_node_keyexpr(&script_pk->key), 3, (uint16_t[]){2, 0, 3}, 0, 1);
+    check_key_expr_musig(r_policy_node_keyexpr(&script_pk->key), 3, (uint16_t[]) {2, 0, 3}, 0, 1);
 }
 
 static void test_get_policy_segwit_version(void **state) {
@@ -438,6 +438,12 @@ static void test_failures(void **state) {
     assert_true(0 > parse_policy("wpkh(musig(@0,@1)/**)", out, sizeof(out)));  // not taproot
     assert_true(
         0 > parse_policy("tr(musig(@0,musig(@1,@2))/**)", out, sizeof(out)));  // can't nest musig
+
+    // musig is currently disabled in multi_a/sortedmulti_a, until the parsing
+    // of such expressions is properly fixed in parse_policy
+    assert_true(0 > parse_policy("tr(@0/**,multi_a(1,musig(@1,@2)/**))", out, sizeof(out)));
+    assert_true(0 >
+                parse_policy("tr(@0/**,sortedmulti_a(2,musig(@1,@2)/**,@3/**))", out, sizeof(out)));
 }
 
 enum TestMode {


### PR DESCRIPTION
The parsing of such fragments is not correctly handled in the current state.
Therefore, we cleanly disable it until the parser is generalized.