### PR TITLE
Add some missing error propagation in `musig.c`

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -381,6 +381,9 @@ void crypto_tr_tagged_hash_init(cx_sha256_t *hash_context, const uint8_t *tag, u
  *   Pointer to a 32-byte array.
  * @param[out]  out
  *   Pointer to an array that will received the output as an uncompressed 65-bytes pubkey.
+ *
+ * @return 0 on success, -1 if x is not the x-coordinate of a point on the curve. On failure, the
+ *   content of `out` is unspecified and must not be used.
  */
 int crypto_tr_lift_x(const uint8_t x[static 32], uint8_t out[static 65]);
 

--- a/src/handler/sign_psbt/musig_signing.c
+++ b/src/handler/sign_psbt/musig_signing.c
@@ -424,7 +424,7 @@ bool __attribute__((noinline)) sign_sighash_musig_and_yield(dispatcher_context_t
     musig_pubnonce_t aggnonce;
     int res = musig_nonce_agg(nonces, musig_info->n, &aggnonce);
     if (res < 0) {
-        PRINTF("Musig aggregation failed; disruptive signer has index %d\n", -res);
+        PRINTF("Musig aggregation failed; disruptive signer has index %d\n", -res - 1);
         SEND_SW(dc, SW_INCORRECT_DATA);
         return false;
     }

--- a/src/musig/musig.c
+++ b/src/musig/musig.c
@@ -204,7 +204,10 @@ int musig_key_agg(const plain_pk_t pubkeys[], size_t n_keys, musig_keyagg_contex
             return -1;
         }
 
-        point_add(&ctx->Q, &P, &ctx->Q);
+        if (CX_OK != point_add(&ctx->Q, &P, &ctx->Q)) {
+            PRINTF("Point addition failed in musig_key_agg\n");
+            return -1;
+        }
     }
 
     if (is_point_infinite(&ctx->Q)) {
@@ -303,9 +306,13 @@ int musig_nonce_agg(const musig_pubnonce_t pubnonces[], size_t n_keys, musig_pub
             point_t R_ij;
             if (0 > cpoint(&pubnonces[i].raw[(j - 1) * sizeof(plain_pk_t)], &R_ij)) {
                 PRINTF("Musig2 nonce aggregation: invalid contribution from cosigner %d\n", i);
-                return -i - 1;
+                return -(int) i - 1;
             }
-            point_add(&R_j, &R_ij, &R_j);
+            if (CX_OK != point_add(&R_j, &R_ij, &R_j)) {
+                // this should never happen
+                PRINTF("Point addition failed for cosigner %d in musig_nonce_agg\n", i);
+                return -(int) i - 1;
+            }
         }
 
         if (is_point_infinite(&R_j)) {
@@ -354,7 +361,9 @@ static int apply_tweak(musig_keyagg_context_t *ctx, const uint8_t tweak[static 3
     }
 
     // compute the resulting tweaked point g * Q + tweak * G
-    point_add(&ctx->Q, &T, &ctx->Q);
+    if (CX_OK != point_add(&ctx->Q, &T, &ctx->Q)) {
+        return -1;
+    }
     if (is_point_infinite(&ctx->Q)) {
         PRINTF("The result of tweaking cannot be infinity\n");
         return -1;

--- a/src/musig/musig.c
+++ b/src/musig/musig.c
@@ -90,7 +90,10 @@ static bool has_even_y(const point_t *P) {
 }
 
 static int cpoint(const uint8_t x[33], point_t *out) {
-    crypto_tr_lift_x(&x[1], out->raw);
+    if (0 > crypto_tr_lift_x(&x[1], out->raw)) {
+        PRINTF("Invalid compressed point: not on curve\n");
+        return -1;
+    }
     if (is_point_infinite(out)) {
         PRINTF("Invalid compressed point\n");
         return -1;


### PR DESCRIPTION
The return value of `crypto_tr_lift_x` and `cpoint` was not consistently checked.